### PR TITLE
Add worktree workflow for parallel development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,65 @@ docs/           Architecture docs, API reference, ADRs
 .claude/        Agents, rules, skills, hooks for Claude Code
 ```
 
+## Worktree Workflow
+
+Every task uses a worktree for isolation. Multiple sessions (human or AI) work in parallel without conflicts.
+
+### Starting a New Task
+
+```bash
+scripts/worktree-create.sh <type> <short-description>
+# Example: scripts/worktree-create.sh feat jetstream-consumers
+# Creates: .claude/worktrees/jetstream-consumers/ on branch feat/jetstream-consumers
+```
+
+The script auto-copies `.env` files and installs dependencies (`npm ci`, `pip install`).
+
+### Submitting Work
+
+```bash
+cd .claude/worktrees/<name>
+git push -u origin <type>/<short-description>
+gh pr create --base main
+```
+
+### After PR Merge — Cleanup
+
+```bash
+scripts/worktree-cleanup.sh <name>        # single worktree
+scripts/worktree-cleanup.sh --all         # all merged worktrees
+scripts/worktree-cleanup.sh --list        # show status of all worktrees
+```
+
+The cleanup script removes the worktree, deletes the local branch, and deletes the remote branch. It warns if the branch is not yet merged.
+
+### PR Feedback After Worktree Removal
+
+When a PR receives review feedback after the worktree was already cleaned up, the branch still exists on the remote. Recreate the worktree from it:
+
+```bash
+scripts/worktree-resume.sh feat/jetstream-consumers   # by branch name
+scripts/worktree-resume.sh 42                          # by PR number
+```
+
+This fetches the branch, recreates the worktree, copies env files, and installs dependencies. You pick up exactly where you left off — make changes, commit, push.
+
+### Multi-Session Parallel Work
+
+- Each session gets its own worktree and branch — git enforces one branch per worktree
+- **Never use `git stash`** — stash is shared across all worktrees and causes cross-session contamination
+- Always commit work-in-progress to the branch instead
+- Each worktree has its own `node_modules`, `.env`, and build artifacts — fully isolated
+- Use `--force-with-lease` (not `--force`) when pushing rebased branches
+
+### Worktree Gotchas
+
+- **Shared across worktrees**: object database, refs, git config, stash, hooks
+- **Isolated per worktree**: HEAD, index (staging), working directory, bisect/rebase state
+- **Branch lock**: a branch checked out in one worktree cannot be checked out in another — use `git worktree prune` if you get stale lock errors
+- **Dependency install required**: each worktree is a fresh directory with no `node_modules` — the scripts handle this automatically
+- **Port conflicts**: if running dev servers in multiple worktrees, assign different ports
+
 ## Critical Gotchas
 
 - SQLite is sync with module-level connection — never use from multiple threads

--- a/scripts/worktree-cleanup.sh
+++ b/scripts/worktree-cleanup.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Clean up a worktree and its branch after merge.
+#
+# Usage:
+#   scripts/worktree-cleanup.sh <name>           # clean up specific worktree
+#   scripts/worktree-cleanup.sh --all             # clean up ALL worktrees
+#   scripts/worktree-cleanup.sh --list            # list worktrees and status
+#
+# Examples:
+#   scripts/worktree-cleanup.sh jetstream-consumers
+#   scripts/worktree-cleanup.sh --all
+
+# --- Resolve repo root ---
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$REPO_ROOT" ]]; then
+    REPO_ROOT="$(git rev-parse --git-common-dir 2>/dev/null | xargs dirname)"
+fi
+
+WORKTREE_BASE="${REPO_ROOT}/.claude/worktrees"
+
+usage() {
+    echo "Usage: $0 <name> | --all | --list"
+    echo ""
+    echo "Commands:"
+    echo "  <name>    Clean up worktree at .claude/worktrees/<name>/ and its branch"
+    echo "  --all     Clean up all worktrees under .claude/worktrees/"
+    echo "  --list    List all worktrees with branch and merge status"
+    exit 1
+}
+
+# Get the branch checked out in a worktree directory
+get_worktree_branch() {
+    local dir="$1"
+    git worktree list --porcelain | awk -v dir="$dir" '
+        /^worktree / { wt=$2 }
+        /^branch /   { if (wt == dir) { sub(/^branch refs\/heads\//, ""); print } }
+    '
+}
+
+# Check if a branch has been merged into main
+is_merged() {
+    local branch="$1"
+    git fetch origin main --quiet 2>/dev/null || true
+    git merge-base --is-ancestor "$branch" origin/main 2>/dev/null
+}
+
+# Clean up a single worktree by name
+cleanup_one() {
+    local name="$1"
+    local worktree_dir="${WORKTREE_BASE}/${name}"
+
+    if [[ ! -d "$worktree_dir" ]]; then
+        echo "Warning: No worktree found at ${worktree_dir}"
+        return 1
+    fi
+
+    local branch
+    branch="$(get_worktree_branch "$worktree_dir")"
+
+    if [[ -z "$branch" ]]; then
+        echo "Warning: Could not determine branch for ${worktree_dir}"
+        echo "  Removing worktree directory only..."
+        git worktree remove "$worktree_dir" --force 2>/dev/null || rm -rf "$worktree_dir"
+        git worktree prune
+        return 0
+    fi
+
+    # Check for uncommitted changes
+    if git -C "$worktree_dir" status --porcelain 2>/dev/null | grep -q .; then
+        echo "Error: Worktree '${name}' has uncommitted changes on branch '${branch}'"
+        echo "  cd ${worktree_dir}"
+        echo "  # commit or discard changes first"
+        return 1
+    fi
+
+    # Check if merged
+    if is_merged "$branch"; then
+        echo "Branch '${branch}' is merged into main."
+    else
+        echo "Warning: Branch '${branch}' is NOT merged into main."
+        read -r -p "  Delete anyway? [y/N] " confirm
+        if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+            echo "  Skipped."
+            return 0
+        fi
+    fi
+
+    # Remove worktree
+    echo "Removing worktree: ${worktree_dir}"
+    git worktree remove "$worktree_dir" --force 2>/dev/null || rm -rf "$worktree_dir"
+    git worktree prune
+
+    # Delete local branch
+    echo "Deleting local branch: ${branch}"
+    git branch -D "$branch" 2>/dev/null || true
+
+    # Delete remote branch
+    if git ls-remote --exit-code --heads origin "$branch" &>/dev/null; then
+        echo "Deleting remote branch: origin/${branch}"
+        git push origin --delete "$branch" 2>/dev/null || true
+    fi
+
+    echo "Cleaned up: ${name} (${branch})"
+    echo ""
+}
+
+# List all worktrees with status
+list_worktrees() {
+    if [[ ! -d "$WORKTREE_BASE" ]] || [[ -z "$(ls -A "$WORKTREE_BASE" 2>/dev/null)" ]]; then
+        echo "No worktrees found under ${WORKTREE_BASE}"
+        return 0
+    fi
+
+    git fetch origin main --quiet 2>/dev/null || true
+
+    printf "%-25s %-35s %-10s %-10s\n" "WORKTREE" "BRANCH" "MERGED" "CLEAN"
+    printf "%-25s %-35s %-10s %-10s\n" "--------" "------" "------" "-----"
+
+    for dir in "${WORKTREE_BASE}"/*/; do
+        [[ -d "$dir" ]] || continue
+        local name
+        name="$(basename "$dir")"
+        local branch
+        branch="$(get_worktree_branch "$dir")"
+
+        local merged="no"
+        if [[ -n "$branch" ]] && is_merged "$branch"; then
+            merged="yes"
+        fi
+
+        local clean="yes"
+        if git -C "$dir" status --porcelain 2>/dev/null | grep -q .; then
+            clean="no"
+        fi
+
+        printf "%-25s %-35s %-10s %-10s\n" "$name" "${branch:-unknown}" "$merged" "$clean"
+    done
+}
+
+# --- Main ---
+
+if [[ $# -ne 1 ]]; then
+    usage
+fi
+
+case "$1" in
+    --list)
+        list_worktrees
+        ;;
+    --all)
+        if [[ ! -d "$WORKTREE_BASE" ]] || [[ -z "$(ls -A "$WORKTREE_BASE" 2>/dev/null)" ]]; then
+            echo "No worktrees to clean up."
+            exit 0
+        fi
+        for dir in "${WORKTREE_BASE}"/*/; do
+            [[ -d "$dir" ]] || continue
+            name="$(basename "$dir")"
+            cleanup_one "$name" || true
+        done
+        echo "Done. Run 'git worktree list' to verify."
+        ;;
+    --help|-h)
+        usage
+        ;;
+    *)
+        cleanup_one "$1"
+        echo "Done. Run 'git worktree list' to verify."
+        ;;
+esac

--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create a new git worktree with a conventionally-named branch.
+#
+# Usage:
+#   scripts/worktree-create.sh <type> <short-description>
+#
+# Examples:
+#   scripts/worktree-create.sh feat jetstream-consumers
+#   scripts/worktree-create.sh fix mqtt-reconnection
+#   scripts/worktree-create.sh docs adr-p2p-delegation
+#
+# Creates:
+#   .claude/worktrees/<short-description>/   (worktree directory)
+#   branch: <type>/<short-description>       (based on latest main)
+
+VALID_TYPES="feat|fix|docs|style|refactor|perf|test|chore|ci|build"
+
+usage() {
+    echo "Usage: $0 <type> <short-description>"
+    echo ""
+    echo "Types: ${VALID_TYPES}"
+    echo ""
+    echo "Examples:"
+    echo "  $0 feat jetstream-consumers"
+    echo "  $0 fix mqtt-reconnection"
+    echo "  $0 docs adr-p2p-delegation"
+    exit 1
+}
+
+# --- Validation ---
+
+if [[ $# -ne 2 ]]; then
+    usage
+fi
+
+TYPE="$1"
+DESC="$2"
+
+if ! echo "$TYPE" | grep -qE "^(${VALID_TYPES})$"; then
+    echo "Error: Invalid type '${TYPE}'"
+    echo "Valid types: ${VALID_TYPES}"
+    exit 1
+fi
+
+if ! echo "$DESC" | grep -qE '^[a-z0-9][a-z0-9-]*[a-z0-9]$'; then
+    echo "Error: Description must be lowercase alphanumeric with hyphens (e.g., 'my-feature')"
+    exit 1
+fi
+
+# --- Resolve repo root ---
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$REPO_ROOT" ]]; then
+    # May be in a worktree — find the main working tree
+    REPO_ROOT="$(git rev-parse --git-common-dir 2>/dev/null | xargs dirname)"
+fi
+
+BRANCH="${TYPE}/${DESC}"
+WORKTREE_DIR="${REPO_ROOT}/.claude/worktrees/${DESC}"
+
+# --- Pre-flight checks ---
+
+if git show-ref --verify --quiet "refs/heads/${BRANCH}" 2>/dev/null; then
+    echo "Error: Branch '${BRANCH}' already exists"
+    echo "  To reuse it:  git worktree add ${WORKTREE_DIR} ${BRANCH}"
+    echo "  To delete it: git branch -d ${BRANCH}"
+    exit 1
+fi
+
+if [[ -d "$WORKTREE_DIR" ]]; then
+    echo "Error: Worktree directory already exists: ${WORKTREE_DIR}"
+    echo "  Clean up with: scripts/worktree-cleanup.sh ${DESC}"
+    exit 1
+fi
+
+# --- Create ---
+
+echo "Updating main..."
+git fetch origin main --quiet
+
+echo "Creating worktree..."
+mkdir -p "${REPO_ROOT}/.claude/worktrees"
+git worktree add -b "${BRANCH}" "${WORKTREE_DIR}" origin/main --quiet
+
+# --- Post-setup: copy env files and install deps ---
+
+echo "Setting up worktree environment..."
+
+# Copy .env files from main repo if they exist
+for env_file in .env .env.local; do
+    if [[ -f "${REPO_ROOT}/${env_file}" ]]; then
+        cp "${REPO_ROOT}/${env_file}" "${WORKTREE_DIR}/${env_file}"
+        echo "  Copied ${env_file}"
+    fi
+done
+
+# Install dependencies if package files exist
+if [[ -f "${WORKTREE_DIR}/frontend/package.json" ]]; then
+    echo "  Installing frontend dependencies..."
+    (cd "${WORKTREE_DIR}/frontend" && npm ci --silent 2>/dev/null) || echo "  Warning: npm ci failed (run manually)"
+fi
+
+if [[ -f "${WORKTREE_DIR}/aggregator/requirements.txt" ]]; then
+    echo "  Installing Python dependencies..."
+    (cd "${WORKTREE_DIR}/aggregator" && pip install -r requirements.txt -q 2>/dev/null) || echo "  Warning: pip install failed (run manually)"
+fi
+
+if [[ -f "${WORKTREE_DIR}/e2e/package.json" ]]; then
+    echo "  Installing e2e dependencies..."
+    (cd "${WORKTREE_DIR}/e2e" && npm ci --silent 2>/dev/null) || echo "  Warning: npm ci failed (run manually)"
+fi
+
+echo ""
+echo "Worktree created:"
+echo "  Branch:    ${BRANCH}"
+echo "  Directory: ${WORKTREE_DIR}"
+echo ""
+echo "Next steps:"
+echo "  cd ${WORKTREE_DIR}"
+echo "  # make changes, commit, push"
+echo "  git push -u origin ${BRANCH}"
+echo "  gh pr create --base main"
+echo ""
+echo "When done:"
+echo "  scripts/worktree-cleanup.sh ${DESC}"

--- a/scripts/worktree-resume.sh
+++ b/scripts/worktree-resume.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resume work on an existing branch by recreating its worktree.
+#
+# Use this when a PR needs changes after the worktree was already removed.
+# The branch still exists (locally or on remote) — this script recreates
+# the worktree from it, installs dependencies, and copies env files.
+#
+# Usage:
+#   scripts/worktree-resume.sh <branch-name>
+#   scripts/worktree-resume.sh <pr-number>
+#
+# Examples:
+#   scripts/worktree-resume.sh feat/jetstream-consumers
+#   scripts/worktree-resume.sh 42    # checks out the branch for PR #42
+#
+# Creates:
+#   .claude/worktrees/<short-description>/   (worktree directory)
+
+usage() {
+    echo "Usage: $0 <branch-name|pr-number>"
+    echo ""
+    echo "Resume work on an existing branch by recreating its worktree."
+    echo "Use after a worktree was cleaned up but the PR still needs changes."
+    echo ""
+    echo "Examples:"
+    echo "  $0 feat/jetstream-consumers"
+    echo "  $0 42    # resume branch from PR #42"
+    exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+    usage
+fi
+
+ARG="$1"
+
+# --- Resolve repo root ---
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$REPO_ROOT" ]]; then
+    REPO_ROOT="$(git rev-parse --git-common-dir 2>/dev/null | xargs dirname)"
+fi
+
+WORKTREE_BASE="${REPO_ROOT}/.claude/worktrees"
+
+# --- Resolve branch name ---
+
+if [[ "$ARG" =~ ^[0-9]+$ ]]; then
+    # PR number — look up the branch via gh CLI
+    if ! command -v gh &>/dev/null; then
+        echo "Error: gh CLI is required to resolve PR numbers"
+        echo "  Install: https://cli.github.com/"
+        exit 1
+    fi
+    BRANCH="$(gh pr view "$ARG" --json headRefName -q .headRefName 2>/dev/null || true)"
+    if [[ -z "$BRANCH" ]]; then
+        echo "Error: Could not find branch for PR #${ARG}"
+        exit 1
+    fi
+    echo "PR #${ARG} → branch: ${BRANCH}"
+else
+    BRANCH="$ARG"
+fi
+
+# --- Derive worktree name from branch ---
+# Branch format: type/short-description → worktree name: short-description
+
+if [[ "$BRANCH" == */* ]]; then
+    WORKTREE_NAME="${BRANCH#*/}"
+else
+    WORKTREE_NAME="$BRANCH"
+fi
+
+WORKTREE_DIR="${WORKTREE_BASE}/${WORKTREE_NAME}"
+
+# --- Pre-flight checks ---
+
+if [[ -d "$WORKTREE_DIR" ]]; then
+    echo "Worktree already exists at ${WORKTREE_DIR}"
+    echo "  cd ${WORKTREE_DIR}"
+    exit 0
+fi
+
+# Prune stale worktree references first
+git worktree prune 2>/dev/null || true
+
+# --- Fetch and resolve branch ---
+
+echo "Fetching latest from origin..."
+git fetch origin --quiet
+
+# Check if branch exists locally
+LOCAL_EXISTS=false
+if git show-ref --verify --quiet "refs/heads/${BRANCH}" 2>/dev/null; then
+    LOCAL_EXISTS=true
+fi
+
+# Check if branch exists on remote
+REMOTE_EXISTS=false
+if git show-ref --verify --quiet "refs/remotes/origin/${BRANCH}" 2>/dev/null; then
+    REMOTE_EXISTS=true
+fi
+
+if ! $LOCAL_EXISTS && ! $REMOTE_EXISTS; then
+    echo "Error: Branch '${BRANCH}' not found locally or on origin"
+    echo ""
+    echo "Available branches:"
+    git branch -a --list "*${WORKTREE_NAME}*" 2>/dev/null || true
+    exit 1
+fi
+
+# --- Create worktree ---
+
+mkdir -p "$WORKTREE_BASE"
+
+if $LOCAL_EXISTS; then
+    echo "Creating worktree from local branch '${BRANCH}'..."
+    git worktree add "$WORKTREE_DIR" "$BRANCH" --quiet
+elif $REMOTE_EXISTS; then
+    echo "Creating worktree from remote branch 'origin/${BRANCH}'..."
+    git worktree add "$WORKTREE_DIR" -b "$BRANCH" "origin/${BRANCH}" --quiet
+fi
+
+# --- Post-setup: copy env files and install deps ---
+
+echo "Setting up worktree environment..."
+
+# Copy .env files from main repo if they exist
+for env_file in .env .env.local; do
+    if [[ -f "${REPO_ROOT}/${env_file}" ]]; then
+        cp "${REPO_ROOT}/${env_file}" "${WORKTREE_DIR}/${env_file}"
+        echo "  Copied ${env_file}"
+    fi
+done
+
+# Install dependencies if package files exist
+if [[ -f "${WORKTREE_DIR}/frontend/package.json" ]]; then
+    echo "  Installing frontend dependencies..."
+    (cd "${WORKTREE_DIR}/frontend" && npm ci --silent 2>/dev/null) || echo "  Warning: npm ci failed (run manually)"
+fi
+
+if [[ -f "${WORKTREE_DIR}/aggregator/requirements.txt" ]]; then
+    echo "  Installing Python dependencies..."
+    (cd "${WORKTREE_DIR}/aggregator" && pip install -r requirements.txt -q 2>/dev/null) || echo "  Warning: pip install failed (run manually)"
+fi
+
+if [[ -f "${WORKTREE_DIR}/e2e/package.json" ]]; then
+    echo "  Installing e2e dependencies..."
+    (cd "${WORKTREE_DIR}/e2e" && npm ci --silent 2>/dev/null) || echo "  Warning: npm ci failed (run manually)"
+fi
+
+echo ""
+echo "Worktree resumed:"
+echo "  Branch:    ${BRANCH}"
+echo "  Directory: ${WORKTREE_DIR}"
+echo ""
+echo "Next steps:"
+echo "  cd ${WORKTREE_DIR}"
+echo "  # address review feedback, commit, push"
+echo "  git push origin ${BRANCH}"
+echo ""
+echo "When done:"
+echo "  scripts/worktree-cleanup.sh ${WORKTREE_NAME}"


### PR DESCRIPTION
## Summary
- Adds standardized worktree workflow to CLAUDE.md with lifecycle docs
- New `scripts/worktree-resume.sh` — recreates worktree from existing branch to address PR feedback (by branch name or PR number)
- Improved `scripts/worktree-create.sh` — now auto-copies `.env` files and installs dependencies
- Includes `scripts/worktree-cleanup.sh` — removes worktree, local/remote branches, warns if unmerged

## Key design decision

When a PR receives review feedback after the worktree is cleaned up, the branch still exists on the remote. `worktree-resume.sh` fetches it and recreates the worktree — no work is lost. This is the cleanest pattern per git documentation and community best practices.

## Test plan
- [ ] Run `scripts/worktree-create.sh feat test-worktree` — verify worktree creation with env copy
- [ ] Run `scripts/worktree-cleanup.sh test-worktree` — verify clean removal
- [ ] Push a branch, remove worktree, run `scripts/worktree-resume.sh feat/test-worktree` — verify recreation
- [ ] Run `scripts/worktree-resume.sh <pr-number>` — verify PR number resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)