### PR TITLE
Phase 4 umbrella: ADRs, schema, contract, configs

### DIFF
--- a/.claude/rules/nats-messaging.md
+++ b/.claude/rules/nats-messaging.md
@@ -11,7 +11,8 @@ paths:
 
 > Authoritative sources: `docs/agent-contract.md`, `schemas/envelope.v1.json`,
 > ADR-0002 (JetStream WorkQueue), ADR-0003 (A2A vocabulary), ADR-0004 (MQTT
-> opt-in), ADR-0005 (browser-scoped token), ADR-0006 (outbox mirror).
+> opt-in), ADR-0005 (browser-scoped token), ADR-0006 (outbox mirror),
+> ADR-0010 (NATS-native L2 delegation), ADR-0011 (MCP for tool exposure).
 > This file is short-form guidance for tools; conflicts in favor of the docs.
 
 ## Transport
@@ -94,6 +95,20 @@ the strict schema at `schemas/envelope.v1.json`:
   `agents.{self}.outbox` via plain NATS (per ADR-0006).
 - Plain-NATS publishes (heartbeat, status, log, broadcast, task_progress)
   do not need `Nats-Msg-Id`.
+
+## Phase 4 surfaces
+
+- In-fleet `delegation` envelopes stay on NATS. Use the L2 helpers at
+  `adapters/_common/l2_orchestrator.py` (Phase 4.2) — do not route in-fleet
+  delegation through A2A HTTP+SSE (ADR-0010).
+- External A2A v1.0 HTTP+SSE traffic enters the fabric only through the
+  `a2a-gateway` service (Phase 4.4). Adapters MUST NOT serve A2A HTTP
+  endpoints directly.
+- Tool exposure to MCP-aware clients (Claude Desktop, Cursor, Hermes,
+  AG2 MCPToolkit) is provided by the `mcp-server` service (Phase 4.3,
+  registered as agent `mcp-1`, `runtime.kind: gateway`). Tools surface
+  fleet primitives 1:1 with NATS / aggregator — no business logic is
+  duplicated (ADR-0011).
 
 ## Auth
 

--- a/adapters/_common/agent_card.py
+++ b/adapters/_common/agent_card.py
@@ -18,11 +18,18 @@ def build_card(config_path: str | Path) -> dict:
     if kind == "bridge" and not runtime.get("upstream"):
         raise ValueError("bridge agents require runtime.upstream")
 
+    conformance = runtime.get("conformance", "L1")
+    if conformance not in ("L1", "L2", "L3"):
+        raise ValueError(
+            f"runtime.conformance must be L1, L2, or L3 (got {conformance!r})"
+        )
+
     metadata = {
         "runtime.kind": kind,
         "runtime.roles": runtime.get("roles", ["worker"]),
         "runtime.heartbeat_interval_sec":
             runtime.get("heartbeat_interval_sec", 30),
+        "runtime.conformance": conformance,
     }
     if runtime.get("tags"):
         metadata["runtime.tags"] = runtime["tags"]

--- a/adapters/_common/tests/test_agent_card.py
+++ b/adapters/_common/tests/test_agent_card.py
@@ -55,3 +55,31 @@ def test_bridge_requires_upstream(tmp_path):
     p = tmp_path / "c.yaml"; p.write_text(bridge_yaml)
     with pytest.raises(ValueError, match="upstream"):
         build_card(p)
+
+
+def test_card_emits_conformance_default_l1(tmp_path):
+    p = tmp_path / "config.yaml"; p.write_text(YAML)
+    card = build_card(p)
+    assert card["metadata"]["runtime.conformance"] == "L1"
+
+
+def test_card_emits_conformance_when_declared(tmp_path):
+    yaml_with_l2 = YAML.replace(
+        "heartbeat_interval_sec: 30\n",
+        "heartbeat_interval_sec: 30\n  conformance: L2\n",
+    )
+    assert yaml_with_l2 != YAML, "replace target not found in YAML fixture"
+    p = tmp_path / "config.yaml"; p.write_text(yaml_with_l2)
+    card = build_card(p)
+    assert card["metadata"]["runtime.conformance"] == "L2"
+
+
+def test_card_rejects_invalid_conformance(tmp_path):
+    yaml_bad = YAML.replace(
+        "heartbeat_interval_sec: 30\n",
+        "heartbeat_interval_sec: 30\n  conformance: L4\n",
+    )
+    assert yaml_bad != YAML, "replace target not found in YAML fixture"
+    p = tmp_path / "config.yaml"; p.write_text(yaml_bad)
+    with pytest.raises(ValueError, match="runtime.conformance"):
+        build_card(p)

--- a/adapters/gemma/config.yaml
+++ b/adapters/gemma/config.yaml
@@ -5,6 +5,7 @@ version: 0.2.5
 runtime:
   kind: native
   roles: [reasoner]
+  conformance: L1
   heartbeat_interval_sec: 30
 capabilities:
   streaming: true

--- a/adapters/hermes/config.yaml
+++ b/adapters/hermes/config.yaml
@@ -6,6 +6,7 @@ runtime:
   kind: bridge
   upstream: hermes-agent
   roles: [reasoner]
+  conformance: L1
   heartbeat_interval_sec: 30
   tags: [external-memory, openai-compat]
 capabilities:

--- a/adapters/shell/config.yaml
+++ b/adapters/shell/config.yaml
@@ -5,6 +5,7 @@ version: 0.1.0
 runtime:
   kind: native
   roles: [worker]
+  conformance: L1
   tags: [shell, executor]
   heartbeat_interval_sec: 30
 skills:

--- a/adapters/watchdog/config.yaml
+++ b/adapters/watchdog/config.yaml
@@ -5,6 +5,7 @@ version: 0.1.0
 runtime:
   kind: native
   roles: [watchdog]
+  conformance: L1
   tags: [observer, infrastructure]
   heartbeat_interval_sec: 30
 skills: []

--- a/docs/05-messaging.md
+++ b/docs/05-messaging.md
@@ -181,6 +181,12 @@ How an operator confirms messaging is healthy:
 
 ---
 
+## Phase 4 surfaces
+
+**Phase 4 binding location** (per ADR-0010 and ADR-0011): the A2A HTTP+SSE binding (reserved in ADR-0003) is implemented by the external A2A ingress gateway (`a2a-gateway/`, Phase 4.4) — purely an external-edge surface. In-fleet delegation does not traverse A2A HTTP; it uses the NATS-native `delegation` envelope on `agents.{recipient}.inbox` via the shared L2 helpers at `adapters/_common/l2_orchestrator.py`. Tool exposure to MCP-aware clients (Claude Desktop, Cursor, Hermes, AG2's MCPToolkit) is provided by the MCP server (`mcp-server/`, Phase 4.3, agent `mcp-1`).
+
+---
+
 ## References
 
 - [`docs/agent-contract.md`](agent-contract.md) — the v0.1 wire contract (envelope, lifecycle, Agent Card).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `task.progress.payload.extra.upstream` — bridge adapters SHOULD set this; native adapters omit it. (`docs/05-messaging.md`).
 - `docs/roadmap.md`: Hermes promoted from parking lot to Phase 6; "MCP server exposing edge-research tools to Hermes" logged as v0.3.
 
+### Phase 4 umbrella (design + contract changes; no runtime code yet)
+
+- Added ADR-0010 (in-fleet delegation is NATS-native; HTTP+SSE A2A is external-only).
+- Added ADR-0011 (MCP is the canonical tool-exposure protocol; promoted from v0.3 parking-lot).
+- `schemas/agent-card.v1.json`: `runtime.kind` enum extends to include `gateway`; `runtime.conformance` becomes mandatory (`L1` | `L2` | `L3`).
+- `adapters/_common/agent_card.py`: factory reads `runtime.conformance` from config; rejects invalid values; defaults to `L1`.
+- All shipped adapters (gemma, hermes, watchdog, shell) annotated `runtime.conformance: L1` in their configs.
+- `docs/agent-contract.md` §3.4 documents the new fields; §4 makes conformance mandatory; §8 (new) introduces the L2 / MCP / external A2A surfaces that land in Phase 4.1–4.4.
+- `docs/roadmap.md`: Phase 4 entries rewritten to match the umbrella spec; "MCP server exposing edge-research tools to Hermes" removed from the parking-lot (now Phase 4.3).
+
+Spec: `docs/superpowers/specs/2026-05-10-phase4-fleet-orchestration-umbrella-design.md`.
+
 ### Added (Phase 2.5)
 
 - **Multi-skill dispatch** in Gemma adapter. Four skills routed by

--- a/docs/adr/0010-nats-native-l2-delegation.md
+++ b/docs/adr/0010-nats-native-l2-delegation.md
@@ -1,0 +1,40 @@
+# ADR-0010: In-fleet delegation is NATS-native; HTTP+SSE A2A is external-only
+
+- **Status:** Proposed (Phase 4 umbrella)
+- **Date:** 2026-05-16
+- **Supersedes:** none
+- **Superseded by:** none
+- **Related:** ADR-0003 (A2A v1.0 vocabulary), ADR-0006 (outbox mirror), ADR-0009 (bridge memory ownership)
+
+## Context
+
+ADR-0003 adopted A2A v1.0 vocabulary in v0.1 and reserved the A2A HTTP+SSE binding for Phase 4. An initial Phase 4 design (2026-05-09 draft) considered using stock `A2aRemoteAgent` over HTTP+SSE for in-fleet delegation, requiring an A2A gateway to act as the in-fleet delegation hub.
+
+That design introduced three under-specified seams:
+
+1. **Provenance loss.** Peers receive envelopes with `sender_id: a2a-gateway` rather than the real originator. Per-sender authorization, `memory.turns.*` keying, and cancel attribution all break when the actual sender is hidden behind the gateway.
+2. **`hop_count` does not cross an A2A boundary natively.** Stock `A2aRemoteAgent` is generic A2A and has no knowledge of EdgeCitadel's `hop_count`. The gateway would have to either invent a custom A2A header or track chain depth itself — both fragile.
+3. **Authorization ambiguity.** A gateway that publishes on behalf of arbitrary callers needs an explicit policy about which `sender_id` values it is allowed to mint. The 2026-05-09 design deferred this to v0.3.
+
+HTTP+SSE round-trips for messages already on the same NATS broker are also pure overhead — a fresh process, a fresh socket, a fresh serialization for traffic that JetStream is already routing.
+
+## Decision
+
+**In-fleet delegation MUST use the NATS-native delegation envelope** (`type: delegation`) on JetStream `agents.{recipient}.inbox`, with the existing dedup and at-least-once contract.
+
+- Adapters acting as L2 orchestrators (AG2, future LangGraph / CrewAI / Pydantic-AI / etc.) use shared helpers in `adapters/_common/l2_orchestrator.py`: `publish_delegation`, `await_result_for_task`, `refuse_if_hop_limit`, `propagate_context`. AG2 (Phase 4.2) is the reference implementation; future frameworks reuse the same helpers without re-deriving the contract.
+- Stock `A2aRemoteAgent` MAY be used for delegation to **external** (non-fleet) A2A endpoints. That is federation; v0.3+ scope.
+- The A2A HTTP+SSE binding (ADR-0003 phase-4 commitment) is implemented by the **external A2A ingress gateway** (Phase 4.4), which translates inbound external A2A traffic into internal NATS commands. The gateway is **not** on the in-fleet delegation path — it is purely external edge.
+
+## Consequences
+
+- One delegation transport to maintain (NATS), one external-protocol surface (the slim A2A gateway), cleanly separated.
+- Provenance is preserved by construction: every delegation envelope carries the real `sender_id`, `context_id`, `hop_count`. Peers can apply per-sender authorization, key memory entries correctly, attribute cancels.
+- The A2A gateway becomes much smaller (only handles untrusted edge traffic; never internal cascades).
+- The L2 substrate (`adapters/_common/l2_orchestrator.py`) becomes the canonical seam for any future orchestrator framework — explicit forward-compat for LangGraph, CrewAI, etc.
+- Future federation (an in-fleet adapter driving an external A2A endpoint) is unconstrained: an adapter can spawn an `A2aRemoteAgent` pointed at a foreign URL when v0.3 needs it; this ADR doesn't forbid that direction, only the *internal-cascade-via-HTTP* anti-pattern.
+
+## Alternatives considered
+
+- **Multiplexing A2A gateway as in-fleet delegation hub** (the 2026-05-09 draft). Rejected on overhead, provenance loss, and substrate-plurality grounds (the L2 contract should be transport-uniform across frameworks).
+- **Internal A2A egress library** that translates `A2aRemoteAgent.send()` to NATS in-process without HTTP. Rejected because it preserves a dependency on AG2's specific A2A client class for what should be a transport-uniform contract — future frameworks shouldn't need to mock `A2aRemoteAgent` to be L2-conformant.

--- a/docs/adr/0011-mcp-for-tool-exposure.md
+++ b/docs/adr/0011-mcp-for-tool-exposure.md
@@ -1,0 +1,41 @@
+# ADR-0011: MCP is the canonical tool-exposure protocol
+
+- **Status:** Proposed (Phase 4 umbrella)
+- **Date:** 2026-05-16
+- **Supersedes:** none
+- **Superseded by:** none
+- **Related:** ADR-0003 (A2A v1.0 vocabulary), ADR-0010 (NATS-native L2)
+
+## Context
+
+The fleet's primitives — publish a command, query the roster, read the message ledger, cancel a task — are useful far beyond the dashboard's HTTP surface. The roadmap's parking lot listed "MCP server exposing edge-research tools to Hermes" as v0.3+; promoting it to Phase 4 multiplies the value of every other deliverable in this phase.
+
+MCP-aware clients are now mainstream: Claude Desktop, Cursor, VS Code (Continue), AG2 (`MCPToolkit`), Hermes Agent (built-in MCP client), future agents. Each gains immediate access to the fleet without an EdgeCitadel-specific code path.
+
+A2A *skills* (the L3 conformance level) and MCP *tools* are not redundant — they have different audiences:
+
+- A2A skills describe what an *agent* offers to another *agent* via the A2A protocol.
+- MCP tools describe what the *fleet as a whole* offers to a *tool-using consumer* (LLM, dev tool, automation script).
+- The same primitive (e.g., "publish a command to gemma-1") can be both an A2A skill on `gemma-1`'s card and an MCP tool on the fleet's MCP server, addressing different consumers.
+
+## Decision
+
+**MCP is the canonical tool-exposure protocol for EdgeCitadel.**
+
+- The MCP server (Phase 4.3) is a first-class fleet subscriber: its own NATS connection, registered as agent `mcp-1` (`runtime.kind: gateway`), heartbeats, audit-trail in the envelope ledger like any other agent.
+- The server speaks MCP over both stdio (local Claude Desktop / Cursor mounts) and HTTP+SSE (remote clients including Hermes' built-in MCP client and AG2's `MCPToolkit`).
+- Tools and resources surface fleet primitives 1:1 with the existing aggregator and NATS surface; no business logic is duplicated. The MCP server's `delegate` tool uses the same `adapters/_common/l2_orchestrator.py` helpers an AG2 orchestrator uses — one substrate, two consumers.
+- The MCP server is **not** the in-fleet delegation hub (per ADR-0010); it's a tool-exposure surface that internally publishes via the same NATS-native delegation contract.
+- Per-caller provenance lives in `payload.metadata.caller` (e.g., `claude-desktop`, `cursor`, an ad-hoc uuid for HTTP+SSE sessions). `sender_id` stays at `mcp-1` because the envelope contract requires sender_ids to match cached Agent Cards.
+
+## Consequences
+
+- One new service (`mcp-server/`) to maintain; new docker-compose entry, new launchd/systemd unit.
+- AG2's L2 orchestrator (Phase 4.2) can use the MCP server as a tool source — the fleet "drinks its own champagne." This is also a forward-compat pattern: future framework orchestrators (LangGraph, CrewAI) can do the same.
+- Hermes (built-in MCP client) can call into the fleet without an EdgeCitadel-specific code path.
+- L3 conformance (A2A typed skills) becomes a separate concern — adapters declare A2A skills on their cards independently of MCP exposure. Phase 4 makes L3 implementable; it does not require every adapter to be L3.
+
+## Alternatives considered
+
+- **Folding MCP support into the A2A gateway.** Rejected: different audiences (tool consumers vs. agent peers), different protocols (MCP vs. A2A), different lifecycles.
+- **Reusing `/api/*` HTTP endpoints with no MCP layer.** Rejected: external clients cannot discover or mount HTTP-only surfaces as MCP tools; the entire point is that MCP is the protocol that *makes them tools*.

--- a/docs/agent-contract.md
+++ b/docs/agent-contract.md
@@ -302,7 +302,8 @@ This is a legitimate use of A2A's documented extension mechanism, not a deviatio
 | `runtime.roles` | yes | Array of role strings: `worker`, `reasoner`, `watchdog`, `orchestrator` |
 | `runtime.tags` | no | Free-form tags (model family, deployment, capabilities) |
 | `runtime.deployment` | no | Deployment identifier, e.g., `mac-mini-studio-01` |
-| `runtime.kind` | yes | `native` (speaks A2A/NATS directly) or `bridge` (facade for an external runtime) |
+| `runtime.kind` | yes | `native` (speaks A2A/NATS directly), `bridge` (facade for an external runtime), or `gateway` (multiplexing surface like the MCP server or external A2A gateway; see §"A2A and MCP surfaces") |
+| `runtime.conformance` | yes | `L1` (reachable), `L2` (collaborative — handles delegation, refuses at `hop_count >= 8`, propagates `context_id`), or `L3` (typed — A2A skill schemas + MCP). See §4. |
 | `runtime.upstream` | required if `runtime.kind = bridge` | Identifier of the upstream runtime |
 | `runtime.heartbeat_interval_sec` | no | Heartbeat interval (default 30 s; range 10–300 s) |
 | `runtime.listens_broadcast` | no | Boolean; defaults to `true` |
@@ -330,7 +331,7 @@ v0.2 replaces this with a JetStream KV bucket (`AGENT_CARDS`).
 | **L2 — Collaborative** | L1 + handles `delegation`, enforces `hop_count >= 8` refusal, propagates `context_id`. | AG2 agents, LangGraph agents, anything that delegates to peers. |
 | **L3 — Typed** | L2 + publishes A2A skill schemas + runs an MCP endpoint. | Agents whose capabilities need to be invoked programmatically by planners. |
 
-An implementation declares its level in `metadata["runtime.conformance"] = "L1" | "L2" | "L3"` (optional; default L1).
+An implementation declares its level in `metadata["runtime.conformance"]`. The field is **mandatory** in v0.2+ (`schemas/agent-card.v1.json` enforces it). Adapters that previously shipped without it default to `"L1"` (gemma, hermes, watchdog, shell). The AG2 adapter ships at `"L2"` after Phase 4.2; `mcp-1` and `a2a-gateway` ship at `"L1"`.
 
 ---
 
@@ -364,6 +365,31 @@ Each adapter is small on purpose. If an adapter is more than ~500 lines, the con
 - [`schemas/agent-card.v1.json`](../schemas/agent-card.v1.json) — A2A v1.0 Agent Card schema (rewritten in Task 2).
 - [`docs/05-messaging.md`](05-messaging.md) — operational view of subjects and persistence.
 - [`docs/superpowers/specs/2026-04-23-agent-messaging-design.md`](superpowers/specs/2026-04-23-agent-messaging-design.md) — full design spec underlying this contract.
+
+---
+
+## 8. A2A and MCP surfaces (Phase 4+)
+
+Phase 4 introduces three new surfaces beyond the v0.1 contract. None changes the envelope schema; they extend the runtime vocabulary.
+
+### 8.1 L2 conformance reference
+
+L2 means the agent handles `delegation` envelopes, enforces `hop_count >= 8` refusal, and propagates `context_id` across hops. The reference implementation is the AG2 adapter (`adapters/ag2/`, Phase 4.2). Shared helpers at `adapters/_common/l2_orchestrator.py` provide:
+
+- `publish_delegation(nc, *, recipient, body, sender_id, context_id, parent_task_id, hop_count, skill_id=None)` — emits a `delegation` envelope on `agents.{recipient}.inbox` with the dedup contract.
+- `await_result_for_task(consumer, task_id, *, timeout)` — awaits the matching `result` on the sender's inbox.
+- `refuse_if_hop_limit(env)` — pre-built rejection envelope when `hop_count >= 8`.
+- `propagate_context(inbound_env, *, new_task_id)` — extracts fields a child delegation must echo.
+
+Future framework adapters (LangGraph, CrewAI, Pydantic-AI, Google ADK) reuse these helpers; ADR-0010 locks NATS-native delegation as the in-fleet transport.
+
+### 8.2 MCP exposure
+
+The MCP server at `mcp-server/` (Phase 4.3) speaks the Model Context Protocol over stdio (Claude Desktop / Cursor mounts) and HTTP+SSE (remote clients including Hermes' built-in MCP client and AG2's `MCPToolkit`). It is a first-class fleet subscriber registered as agent `mcp-1` (`runtime.kind: gateway`, `runtime.roles: [orchestrator]`, `runtime.conformance: L1`). Tools surfaced (1:1 with NATS / aggregator primitives): `publish_command`, `list_agents`, `query_messages`, `cancel_task`, `delegate`. Per-caller attribution lives in `payload.metadata.caller`. See ADR-0011.
+
+### 8.3 External A2A ingress
+
+The A2A gateway at `a2a-gateway/` (Phase 4.4) is a slim FastAPI service exposing A2A v1.0 HTTP+SSE endpoints for any agent whose `runtime.roles` overlaps `{reasoner, worker}`. It is registered as agent `a2a-gateway` (`runtime.kind: gateway`). The gateway is purely external-edge — it never participates in in-fleet delegation (ADR-0010). Per-session attribution lives in `payload.metadata.origin_session`.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@ This file tracks deferred work and the path forward beyond what's currently impl
 1. **[Out of scope — deferred enhancements](#out-of-scope--deferred-enhancements)** — items intentionally cut from current specs, with the design hooks already in place to land them later without contract changes.
 2. **[Phase handover — delayed-to-later-phases](#phase-handover--delayed-to-later-phases)** — explicit work items pushed to specific future phases, each with the spec entry point.
 
-Last updated: 2026-05-09.
+Last updated: 2026-05-16.
 
 ---
 
@@ -108,27 +108,27 @@ New `Registry` top-level tab + `GET /api/registry` snapshot endpoint +
 `agent_deleted` WS event + sidebar roles-based filter so infrastructure
 agents only appear in Registry, not Chat.
 
-### Phase 4 — AG2 + A2A wrapper
+### Phase 4 — Fleet orchestration & protocol extensions
 
-Four sessions, one plan. The first phase that exercises the **bridge** pattern (`runtime.kind: bridge`).
+Four sub-specs under one umbrella. Adds the first L2-conformant orchestrator (AG2), an MCP server exposing fleet primitives as tools, and an external A2A ingress gateway. ADR-0010 locks in-fleet delegation as NATS-native; ADR-0011 establishes MCP as the canonical tool-exposure protocol. Original roadmap ordering restored: 4.1 → 4.2 → 4.3 → 4.4.
 
-#### Phase 4.1 — AG2 adapter L1 scaffold
+#### Phase 4.1 — AG2 adapter scaffold
 
-Pin `ag2>=0.12,<0.13`. Spend 15 minutes verifying imports (`A2aRemoteAgent`, `A2aAgentServer`, `autogen.agentchat.group.AutoPattern`) against the pinned wheel before writing code. Use `a_run` async-only.
+Pin `ag2>=0.12,<0.13`. Native runtime, single `reasoning.chat` skill, uses `memory.turns.*` like Gemma. Validates AG2 imports against the pinned wheel. `runtime.conformance: L1`. Indistinguishable from `gemma-1` on the fabric except for the `ag2` tag.
 
-#### Phase 4.2 — AG2 L2 delegation + hop_count loop protection
+#### Phase 4.2 — AG2 as L2 orchestrator + L2 substrate
 
-Refuse delegations at `hop_count >= 8`. Cancel returns `task_state: rejected, payload.reason: "ag2_cancel_not_supported"` (v0.2 limitation; revisit if/when AG2 ships cancel).
+Custom AG2 function-tool `delegate(...)` publishes NATS-native `delegation` envelopes. Shared helpers extracted into `adapters/_common/l2_orchestrator.py` so future framework adapters (LangGraph, CrewAI, …) reuse the L2 contract without re-deriving it. Refuses delegations pre-emptively at `hop_count >= 7` (inbound). Cancel returns `task_state: rejected, payload.reason: "ag2_cancel_not_supported"`. `runtime.conformance` bumps to L2. `docs/06-p2p-delegation.md` rewritten in the same PR.
 
-#### Phase 4.3 — Dashboard delegation-chain view
+#### Phase 4.3 — MCP server (first-class subscriber)
 
-`GET /api/chains/{context_id}` endpoint + chain timeline UI. Visualizes a delegation cascade across multiple agents.
+New `mcp-server/` service. First-class NATS subscriber registered as `mcp-1` (`runtime.kind: gateway`). Speaks MCP over both stdio (Claude Desktop / Cursor) and HTTP+SSE (remote, including Hermes' built-in MCP client and AG2's `MCPToolkit`). Tools: `publish_command`, `list_agents`, `query_messages`, `cancel_task`, `delegate`. AG2's L2 orchestrator drinks own champagne via the MCP server.
 
-#### Phase 4.4 — A2A HTTP wrapper
+#### Phase 4.4 — External A2A ingress gateway
 
-`A2aAgentServer(agent, agent_card=card)` serving `/.well-known/agent-card.json`. NATS bridge translates SSE → `task.progress` envelopes. Decide `.build()` vs `.serve()` vs `.run()` at pin time.
+Slim FastAPI service translating external A2A v1.0 HTTP+SSE into internal NATS commands. Role filter (`runtime.roles ∩ {reasoner, worker}`) gates which agents are exposed. Registered as `a2a-gateway` (`runtime.kind: gateway`). Strictly external-edge — never on the in-fleet delegation path (ADR-0010).
 
-Spec file: `docs/superpowers/specs/<date>-ag2-a2a-wrapper-design.md` (TBD).
+Umbrella spec: `docs/superpowers/specs/2026-05-10-phase4-fleet-orchestration-umbrella-design.md`. Sub-spec files land per-sub-phase.
 
 ### Phase 5 — Host deploy ✅ shipped 2026-05-09
 
@@ -198,7 +198,6 @@ Hermes upstream provider: `custom` endpoint pointed at OpenAI (`https://api.open
 
 ### Optional / parking lot
 
-- **MCP server exposing edge-research tools to Hermes.** Symmetric half of the Phase 6 Hermes bridge. Lets Hermes call into edge-research (publish to NATS, query the agent roster, trigger watchdog actions). v0.3+; design hook reserved in `docs/superpowers/specs/2026-05-05-hermes-bridge-design.md` §Non-goals.
 - **Per-agent JWT auth** (replaces shared `NATS_TOKEN`). v0.2+. Necessary for multi-tenant deployments.
 - **JetStream clustering.** Single-node broker is fine until a second persistent host joins (likely v0.3+).
 - **P2P transport (Zenoh).** v0.3+ exploration; only relevant if we want agent-to-agent communication that doesn't traverse the central broker.

--- a/schemas/agent-card.v1.json
+++ b/schemas/agent-card.v1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://edgecitadel.dev/schemas/agent-card.v1.json",
   "title": "A2A v1.0 Agent Card (EdgeCitadel profile)",
-  "description": "Payload of agents.{id}.register. Full A2A v1.0 Agent Card shape with EdgeCitadel metadata vocabulary (runtime.kind, runtime.roles, runtime.upstream, runtime.heartbeat_interval_sec).",
+  "description": "Payload of agents.{id}.register. Full A2A v1.0 Agent Card shape with EdgeCitadel metadata vocabulary (runtime.kind ∈ {native,bridge,gateway}, runtime.roles, runtime.upstream, runtime.conformance ∈ {L1,L2,L3}, runtime.heartbeat_interval_sec).",
   "type": "object",
   "additionalProperties": true,
   "required": ["name", "description", "version", "url", "provider",
@@ -69,9 +69,11 @@
     "metadata": {
       "type": "object",
       "required": ["runtime.kind", "runtime.roles",
+                   "runtime.conformance",
                    "runtime.heartbeat_interval_sec"],
       "properties": {
-        "runtime.kind": {"type": "string", "enum": ["native", "bridge"]},
+        "runtime.kind": {"type": "string", "enum": ["native", "bridge", "gateway"]},
+        "runtime.conformance": {"type": "string", "enum": ["L1", "L2", "L3"]},
         "runtime.roles": {
           "type": "array",
           "minItems": 1,

--- a/schemas/tests/test_agent_card_schema.py
+++ b/schemas/tests/test_agent_card_schema.py
@@ -38,6 +38,7 @@ def _card(**over):
         "metadata": {
             "runtime.kind": "native",
             "runtime.roles": ["worker"],
+            "runtime.conformance": "L1",
             "runtime.heartbeat_interval_sec": 30
         }
     }
@@ -53,6 +54,21 @@ class TestAccepts:
         c = _card()
         c["metadata"] = {**c["metadata"], "runtime.kind": "bridge",
                          "runtime.upstream": "nous-hermes-agent"}
+        validator.validate(c)
+
+    def test_gateway_kind_accepted(self, validator):
+        c = _card()
+        c["metadata"] = {**c["metadata"], "runtime.kind": "gateway"}
+        validator.validate(c)
+
+    def test_conformance_l2_accepted(self, validator):
+        c = _card()
+        c["metadata"] = {**c["metadata"], "runtime.conformance": "L2"}
+        validator.validate(c)
+
+    def test_conformance_l3_accepted(self, validator):
+        c = _card()
+        c["metadata"] = {**c["metadata"], "runtime.conformance": "L3"}
         validator.validate(c)
 
 
@@ -77,5 +93,19 @@ class TestRejects:
     def test_heartbeat_out_of_range(self, validator):
         c = _card()
         c["metadata"] = {**c["metadata"], "runtime.heartbeat_interval_sec": 5}
+        with pytest.raises(ValidationError):
+            validator.validate(c)
+
+    def test_missing_conformance(self, validator):
+        c = _card()
+        m = dict(c["metadata"])
+        m.pop("runtime.conformance")
+        c["metadata"] = m
+        with pytest.raises(ValidationError):
+            validator.validate(c)
+
+    def test_bad_conformance_value(self, validator):
+        c = _card()
+        c["metadata"] = {**c["metadata"], "runtime.conformance": "L4"}
         with pytest.raises(ValidationError):
             validator.validate(c)


### PR DESCRIPTION
## Summary

Lands the Phase 4 umbrella — design + contract changes only, no runtime code. Scopes the four sub-phases that follow (4.1 AG2 adapter, 4.2 L2 orchestrator, 4.3 MCP server, 4.4 external A2A gateway) by establishing two ADRs and tightening the agent-card contract.

- **ADR-0010**: in-fleet delegation is NATS-native; HTTP+SSE A2A is external-only. Locks the L2 transport before the orchestrator lands.
- **ADR-0011**: MCP is the canonical tool-exposure protocol. Promotes the previously-v0.3-parking-lot MCP server to a Phase 4.3 deliverable.
- **Schema**: `runtime.kind` enum gains `gateway`; `runtime.conformance` (L1/L2/L3) becomes mandatory.
- **Adapters**: gemma, hermes, watchdog, shell each declare `runtime.conformance: L1`. Factory at `adapters/_common/agent_card.py` reads the field with a default of L1 (back-compat) and validates against the enum.
- **Docs**: `agent-contract.md` §3.4/§4 updated, new §8 covering L2/MCP/external-A2A surfaces; `roadmap.md` Phase 4 entries rewritten; `05-messaging.md` and `.claude/rules/nats-messaging.md` reference the new surfaces; CHANGELOG entry under Unreleased.

The 2026-05-09 draft umbrella (in the gitignored `docs/superpowers/specs/` dir) was superseded after architectural review and removed locally.

Umbrella spec: `docs/superpowers/specs/2026-05-10-phase4-fleet-orchestration-umbrella-design.md` (gitignored per repo convention).

## Test plan

- [x] `pytest schemas/ adapters/ aggregator/tests/` (targeted, excluding the two pre-existing broken files): 117 pass
- [x] All four shipped adapter cards validate against the tightened schema (gemma/hermes/watchdog/shell — all kind+conformance fields emit correctly)
- [x] No envelope-schema changes; no new persistence tables
- [ ] CI green on this branch
- [ ] Sub-spec 4.1 (AG2 adapter scaffold) drafted after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)