### PR TITLE
Add finance research workspace, new tabs, and agent console refactor

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,7 +17,7 @@ export default function App() {
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e) => {
-      // Tab switching with 1-5
+      // Product tab switching with 1-5
       if (!e.ctrlKey && !e.metaKey && !e.altKey) {
         const target = e.target
         if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT') {
@@ -25,19 +25,19 @@ export default function App() {
         }
         switch (e.key) {
           case '1':
-            setActiveTab('chat')
+            setActiveTab('market')
             break
           case '2':
-            setActiveTab('flow')
+            setActiveTab('research')
             break
           case '3':
-            setActiveTab('logs')
+            setActiveTab('portfolio')
             break
           case '4':
-            setActiveTab('tasks')
+            setActiveTab('alerts')
             break
           case '5':
-            setActiveTab('registry')
+            setActiveTab('agents')
             break
         }
       }

--- a/frontend/src/Layout.jsx
+++ b/frontend/src/Layout.jsx
@@ -1,55 +1,70 @@
-import { MessageSquare, GitBranch, FileText, ListTodo, Server } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import {
+  Bell,
+  Briefcase,
+  LayoutDashboard,
+  LineChart,
+  MessageSquare,
+  Search,
+} from 'lucide-react'
 import clsx from 'clsx'
 import useAppStore from './stores/appStore'
 import HeaderBar from './components/HeaderBar'
-import AgentSidebar from './components/AgentSidebar'
-import ChatHistory from './components/ChatHistory'
-import CommFlow from './components/CommFlow'
-import LogViewer from './components/LogViewer'
-import TaskBoard from './components/TaskBoard'
-import AgentDetail from './components/AgentDetail'
-import AgentRegistry from './components/AgentRegistry'
+import StockWorkspace from './components/StockWorkspace'
+import MarketOverview from './components/MarketOverview'
+import PortfolioWorkspace from './components/PortfolioWorkspace'
+import AlertCenter from './components/AlertCenter'
+import AgentsConsole from './components/AgentsConsole'
 
 const TABS = [
-  { key: 'chat', label: 'Chat', icon: MessageSquare, shortcut: '1' },
-  { key: 'flow', label: 'Flow', icon: GitBranch, shortcut: '2' },
-  { key: 'logs', label: 'Logs', icon: FileText, shortcut: '3' },
-  { key: 'tasks', label: 'Tasks', icon: ListTodo, shortcut: '4' },
-  { key: 'registry', label: 'Registry', icon: Server, shortcut: '5' },
+  { key: 'market', label: 'Market', icon: LayoutDashboard, shortcut: '1' },
+  { key: 'research', label: 'Research', icon: Search, shortcut: '2' },
+  { key: 'portfolio', label: 'Portfolio', icon: Briefcase, shortcut: '3' },
+  { key: 'alerts', label: 'Alerts', icon: Bell, shortcut: '4' },
+  { key: 'agents', label: 'Agents', icon: MessageSquare, shortcut: '5' },
 ]
 
 export default function Layout() {
   const activeTab = useAppStore((s) => s.activeTab)
   const setActiveTab = useAppStore((s) => s.setActiveTab)
   const selectedAgent = useAppStore((s) => s.selectedAgent)
-  const setSelectedAgent = useAppStore((s) => s.setSelectedAgent)
   const sidebarOpen = useAppStore((s) => s.sidebarOpen)
   const setSidebarOpen = useAppStore((s) => s.setSidebarOpen)
+  const [agentConsoleTab, setAgentConsoleTab] = useState('chat')
 
-  const showDetail = activeTab === 'detail' && selectedAgent
+  // Legacy deep links still used by agent rows and keyboard regression tests.
+  useEffect(() => {
+    if (['chat', 'flow', 'logs', 'tasks', 'registry', 'detail'].includes(activeTab)) {
+      setAgentConsoleTab(activeTab === 'detail' ? 'chat' : activeTab)
+    }
+  }, [activeTab])
+
+  const normalizedActiveTab = ['chat', 'flow', 'logs', 'tasks', 'registry', 'detail'].includes(activeTab)
+    ? 'agents'
+    : activeTab
 
   const renderContent = () => {
-    if (showDetail) {
-      return (
-        <AgentDetail
-          agentId={selectedAgent}
-          onBack={() => setActiveTab('chat')}
-        />
-      )
-    }
-    switch (activeTab) {
-      case 'chat':
-        return <ChatHistory />
-      case 'flow':
-        return <CommFlow />
-      case 'logs':
-        return <LogViewer />
-      case 'tasks':
-        return <TaskBoard />
-      case 'registry':
-        return <AgentRegistry />
+    switch (normalizedActiveTab) {
+      case 'market':
+        return <MarketOverview />
+      case 'research':
+        return <StockWorkspace />
+      case 'portfolio':
+        return <PortfolioWorkspace />
+      case 'alerts':
+        return <AlertCenter />
+      case 'agents':
+        return (
+          <AgentsConsole
+            activeSubTab={activeTab === 'detail' && selectedAgent ? 'detail' : agentConsoleTab}
+            onSubTabChange={(tab) => {
+              setAgentConsoleTab(tab)
+              setActiveTab(tab)
+            }}
+          />
+        )
       default:
-        return <ChatHistory />
+        return <MarketOverview />
     }
   }
 
@@ -57,7 +72,6 @@ export default function Layout() {
     <div className="h-screen flex flex-col bg-surface">
       <HeaderBar />
       <div className="flex flex-1 min-h-0">
-        {/* Mobile sidebar backdrop */}
         {sidebarOpen && (
           <div
             className="fixed inset-0 bg-black/50 z-30 md:hidden"
@@ -65,21 +79,12 @@ export default function Layout() {
           />
         )}
 
-        {/* Sidebar: fixed overlay on mobile, static in flex on desktop */}
-        <div
-          className={clsx(
-            'fixed top-12 bottom-0 left-0 z-40 w-64 transition-transform duration-200 ease-in-out',
-            'md:static md:w-60 md:translate-x-0 md:transition-none',
-            sidebarOpen ? 'translate-x-0' : '-translate-x-full'
-          )}
-        >
-          <AgentSidebar />
-        </div>
-
-        {/* Main content */}
         <div className="flex-1 flex flex-col min-h-0 min-w-0">
-          {/* Tab bar */}
           <div className="flex items-center border-b border-surface-200 bg-surface-50 overflow-x-auto">
+            <div className="hidden md:flex items-center gap-1 px-3 py-2 text-xs text-gray-500 border-r border-surface-200">
+              <LineChart size={14} className="text-accent" />
+              Research Terminal
+            </div>
             {TABS.map((tab) => {
               const Icon = tab.icon
               return (
@@ -89,7 +94,7 @@ export default function Layout() {
                   className={clsx(
                     'flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium transition-colors border-b-2 whitespace-nowrap',
                     'md:px-4',
-                    activeTab === tab.key
+                    normalizedActiveTab === tab.key
                       ? 'text-accent-light border-accent'
                       : 'text-gray-500 border-transparent hover:text-gray-300'
                   )}
@@ -104,7 +109,6 @@ export default function Layout() {
             })}
           </div>
 
-          {/* Content */}
           <div className="flex-1 min-h-0 flex flex-col">{renderContent()}</div>
         </div>
       </div>

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -54,6 +54,23 @@ export const api = {
 
   // Registry — fleet snapshot used by the Registry tab
   getRegistry: () => req('/registry'),
+
+  // Finance research endpoints. These are intentionally thin wrappers so the
+  // frontend can move from demo data to live market providers without changing
+  // component code.
+  getQuote: (symbol) => req(`/market/quote/${encodeURIComponent(symbol)}`),
+  getBatchQuotes: (symbols) => req(`/market/quotes?symbols=${encodeURIComponent(symbols.join(','))}`),
+  getCandles: (symbol, range = '1Y', interval = '1w') =>
+    req(`/market/candles/${encodeURIComponent(symbol)}?range=${encodeURIComponent(range)}&interval=${encodeURIComponent(interval)}`),
+  getFundamentals: (symbol) => req(`/research/fundamentals/${encodeURIComponent(symbol)}`),
+  getValuation: (symbol) => req(`/research/valuation/${encodeURIComponent(symbol)}`),
+  getNewsEvents: (symbol) => req(`/research/events/${encodeURIComponent(symbol)}`),
+  getPortfolio: () => req('/portfolio'),
+  getPositions: () => req('/portfolio/positions'),
+  getAlerts: (params = {}) => {
+    const qs = new URLSearchParams(Object.entries(params).filter(([, v]) => v !== undefined && v !== null && v !== '')).toString()
+    return req(`/alerts${qs ? `?${qs}` : ''}`)
+  },
 }
 
 export default api

--- a/frontend/src/components/AgentsConsole.jsx
+++ b/frontend/src/components/AgentsConsole.jsx
@@ -1,0 +1,90 @@
+import { GitBranch, FileText, ListTodo, MessageSquare, Server } from 'lucide-react'
+import clsx from 'clsx'
+import useAppStore from '../stores/appStore'
+import AgentSidebar from './AgentSidebar'
+import ChatHistory from './ChatHistory'
+import CommFlow from './CommFlow'
+import LogViewer from './LogViewer'
+import TaskBoard from './TaskBoard'
+import AgentDetail from './AgentDetail'
+import AgentRegistry from './AgentRegistry'
+
+const AGENT_TABS = [
+  { key: 'chat', label: 'Chat', icon: MessageSquare },
+  { key: 'flow', label: 'Flow', icon: GitBranch },
+  { key: 'logs', label: 'Logs', icon: FileText },
+  { key: 'tasks', label: 'Tasks', icon: ListTodo },
+  { key: 'registry', label: 'Registry', icon: Server },
+]
+
+export default function AgentsConsole({ activeSubTab, onSubTabChange }) {
+  const selectedAgent = useAppStore((s) => s.selectedAgent)
+  const sidebarOpen = useAppStore((s) => s.sidebarOpen)
+  const setSidebarOpen = useAppStore((s) => s.setSidebarOpen)
+  const setActiveTab = useAppStore((s) => s.setActiveTab)
+
+  const renderAgentContent = () => {
+    if (activeSubTab === 'detail' && selectedAgent) {
+      return <AgentDetail agentId={selectedAgent} onBack={() => setActiveTab('chat')} />
+    }
+    switch (activeSubTab) {
+      case 'flow':
+        return <CommFlow />
+      case 'logs':
+        return <LogViewer />
+      case 'tasks':
+        return <TaskBoard />
+      case 'registry':
+        return <AgentRegistry />
+      case 'chat':
+      default:
+        return <ChatHistory />
+    }
+  }
+
+  return (
+    <div className="flex flex-1 min-h-0 overflow-hidden">
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 z-30 md:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+      <div
+        className={clsx(
+          'fixed top-24 bottom-0 left-0 z-40 w-64 transition-transform duration-200 ease-in-out',
+          'md:static md:w-60 md:translate-x-0 md:transition-none',
+          sidebarOpen ? 'translate-x-0' : '-translate-x-full'
+        )}
+      >
+        <AgentSidebar />
+      </div>
+      <div className="flex-1 flex flex-col min-w-0 min-h-0">
+        <div className="flex items-center gap-1 px-2 py-2 border-b border-surface-200 bg-surface/60 overflow-x-auto">
+          <span className="px-2 text-[10px] uppercase tracking-[0.14em] text-gray-600 shrink-0">
+            Agent Console
+          </span>
+          {AGENT_TABS.map((tab) => {
+            const Icon = tab.icon
+            return (
+              <button
+                key={tab.key}
+                onClick={() => onSubTabChange(tab.key)}
+                className={clsx(
+                  'flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs transition-colors whitespace-nowrap',
+                  activeSubTab === tab.key
+                    ? 'bg-accent/20 text-accent-light'
+                    : 'text-gray-500 hover:text-gray-300 hover:bg-surface-100'
+                )}
+              >
+                <Icon size={13} />
+                {tab.label}
+              </button>
+            )
+          })}
+        </div>
+        <div className="flex-1 min-h-0 flex flex-col">{renderAgentContent()}</div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/AlertCenter.jsx
+++ b/frontend/src/components/AlertCenter.jsx
@@ -1,0 +1,38 @@
+import clsx from 'clsx'
+import { alerts } from '../data/financeMockData'
+
+const severityClass = {
+  high: 'bg-red-500/20 text-red-300',
+  medium: 'bg-yellow-500/20 text-yellow-300',
+  low: 'bg-blue-500/20 text-blue-300',
+}
+
+export default function AlertCenter() {
+  return (
+    <div className="flex-1 overflow-y-auto p-3 md:p-4 space-y-4">
+      <section className="bg-surface-50 border border-surface-200 rounded-xl p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-100">Alert Center</h2>
+            <p className="text-xs text-gray-500">Rules for price, volume, sentiment, agent rating changes, and portfolio exposure.</p>
+          </div>
+          <button className="bg-accent hover:bg-accent-dark text-white px-3 py-1.5 rounded text-xs">New rule</button>
+        </div>
+      </section>
+      <section className="grid gap-3">
+        {alerts.map((alert) => (
+          <div key={alert.id} className="bg-surface-50 border border-surface-200 rounded-xl p-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-mono text-gray-100">{alert.symbol}</span>
+              <span className={clsx('px-2 py-0.5 rounded text-[10px] uppercase', severityClass[alert.severity])}>{alert.severity}</span>
+              <span className={clsx('px-2 py-0.5 rounded text-[10px]', alert.status === 'open' ? 'bg-green-500/20 text-green-300' : 'bg-surface-100 text-gray-500')}>{alert.status}</span>
+              <span className="ml-auto text-[10px] text-gray-600">{alert.time}</span>
+            </div>
+            <div className="mt-2 text-sm text-gray-300">{alert.rule}</div>
+            <div className="mt-1 text-xs text-gray-500">{alert.trigger}</div>
+          </div>
+        ))}
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/components/FundamentalsPanel.jsx
+++ b/frontend/src/components/FundamentalsPanel.jsx
@@ -1,0 +1,49 @@
+import { Bar, BarChart, CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import { fundamentals, peers } from '../data/financeMockData'
+
+export default function FundamentalsPanel() {
+  return (
+    <section className="grid lg:grid-cols-2 gap-4">
+      <div className="bg-surface-50 border border-surface-200 rounded-xl p-4">
+        <h3 className="text-sm font-semibold text-gray-200">Fundamentals</h3>
+        <p className="text-[10px] text-gray-600 mb-3">Revenue, EPS, margin, and free cash flow trends.</p>
+        <div className="h-56">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={fundamentals} margin={{ left: -12, right: 8 }}>
+              <CartesianGrid stroke="#1f2937" strokeDasharray="3 3" />
+              <XAxis dataKey="period" tick={{ fill: '#6b7280', fontSize: 10 }} />
+              <YAxis tick={{ fill: '#6b7280', fontSize: 10 }} />
+              <Tooltip contentStyle={{ background: '#111827', border: '1px solid #374151' }} />
+              <Legend wrapperStyle={{ fontSize: 10 }} />
+              <Bar dataKey="revenue" fill="#38bdf8" name="Revenue ($B)" />
+              <Bar dataKey="fcf" fill="#34d399" name="FCF ($B)" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+      <div className="bg-surface-50 border border-surface-200 rounded-xl p-4">
+        <h3 className="text-sm font-semibold text-gray-200">Valuation & Peers</h3>
+        <p className="text-[10px] text-gray-600 mb-3">Peer snapshot for growth, margins, and forward multiples.</p>
+        <div className="h-32 mb-3">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={fundamentals} margin={{ left: -12, right: 8 }}>
+              <XAxis dataKey="period" tick={{ fill: '#6b7280', fontSize: 10 }} />
+              <YAxis tick={{ fill: '#6b7280', fontSize: 10 }} />
+              <Tooltip contentStyle={{ background: '#111827', border: '1px solid #374151' }} />
+              <Line type="monotone" dataKey="margin" stroke="#f59e0b" strokeWidth={2} name="Net margin %" />
+              <Line type="monotone" dataKey="eps" stroke="#a78bfa" strokeWidth={2} name="EPS" />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead className="text-gray-500"><tr><th className="text-left py-1">Peer</th><th>Growth</th><th>GM</th><th>Fwd P/E</th><th>EV/S</th><th>Agent</th></tr></thead>
+            <tbody className="text-gray-300">
+              {peers.map((p) => <tr key={p.symbol} className="border-t border-surface-200"><td className="py-1 font-mono">{p.symbol}</td><td className="text-center">{p.growth}%</td><td className="text-center">{p.grossMargin}%</td><td className="text-center">{p.forwardPE}x</td><td className="text-center">{p.evSales}x</td><td className="text-center">{p.rating}</td></tr>)}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/HeaderBar.jsx
+++ b/frontend/src/components/HeaderBar.jsx
@@ -51,8 +51,8 @@ export default function HeaderBar() {
 
         <Radio size={18} className="text-accent shrink-0" />
         <h1 className="text-sm font-semibold text-gray-100 truncate">
-          <span className="hidden sm:inline">OpenClaw Swarm Control</span>
-          <span className="sm:hidden">OpenClaw</span>
+          <span className="hidden sm:inline">EdgeCitadel Research Agent</span>
+          <span className="sm:hidden">EdgeCitadel</span>
         </h1>
         <StatusBadge
           status={wsConnected ? 'online' : 'error'}

--- a/frontend/src/components/MarketOverview.jsx
+++ b/frontend/src/components/MarketOverview.jsx
@@ -1,0 +1,35 @@
+import clsx from 'clsx'
+import { marketIndexes, sectorPerformance } from '../data/financeMockData'
+import StockWorkspace from './StockWorkspace'
+
+function Change({ value }) {
+  return <span className={clsx(value >= 0 ? 'text-green-400' : 'text-red-400')}>{value >= 0 ? '+' : ''}{value.toFixed(2)}%</span>
+}
+
+export default function MarketOverview() {
+  return (
+    <div className="flex-1 overflow-y-auto p-3 md:p-4 space-y-4">
+      <section className="grid md:grid-cols-4 gap-3">
+        {marketIndexes.map((idx) => (
+          <div key={idx.symbol} className="bg-surface-50 border border-surface-200 rounded-xl p-3">
+            <div className="flex items-center justify-between"><div className="text-sm font-semibold text-gray-100">{idx.symbol}</div><Change value={idx.changePercent} /></div>
+            <div className="text-[10px] text-gray-500 mt-1">{idx.label}</div>
+            <div className="mt-2 text-lg font-mono text-gray-200">${idx.price}</div>
+          </div>
+        ))}
+      </section>
+      <section className="bg-surface-50 border border-surface-200 rounded-xl p-4">
+        <h3 className="text-sm font-semibold text-gray-200 mb-3">Sector Heatmap</h3>
+        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-2">
+          {sectorPerformance.map((sector) => (
+            <div key={sector.name} className={clsx('rounded-lg p-3 border', sector.changePercent >= 0 ? 'bg-green-500/10 border-green-500/20' : 'bg-red-500/10 border-red-500/20')}>
+              <div className="text-xs text-gray-300">{sector.name}</div>
+              <div className="mt-1 text-lg font-mono"><Change value={sector.changePercent} /></div>
+            </div>
+          ))}
+        </div>
+      </section>
+      <StockWorkspace />
+    </div>
+  )
+}

--- a/frontend/src/components/MessageBubble.jsx
+++ b/frontend/src/components/MessageBubble.jsx
@@ -17,6 +17,7 @@ import {
 import { getAgentColor } from '../utils/agentColors'
 import { relativeTime, fullTimestamp } from '../utils/formatTime'
 import MessageInspector from './MessageInspector'
+import StockAnalysisCard from './StockAnalysisCard'
 
 const typeConfig = {
   command: { icon: Terminal, color: 'text-blue-400' },
@@ -144,6 +145,11 @@ export default function MessageBubble({ message, highlighted, onClick, commandSk
   const config = typeConfig[displayType] || typeConfig[type] || { icon: Info, color: 'text-gray-400' }
   const Icon = config.icon
   const senderColor = getAgentColor(message.sender_id)
+  const stockAnalysis = message.payload?.type === 'stock_analysis'
+    ? message.payload
+    : message.payload?.result?.type === 'stock_analysis'
+      ? message.payload.result
+      : null
   const content = extractContent(message.payload) ?? message.content ?? null
   const taskState = message.task_state
 
@@ -243,8 +249,14 @@ export default function MessageBubble({ message, highlighted, onClick, commandSk
           </span>
         </div>
 
+        {stockAnalysis && (
+          <div className="mt-2">
+            <StockAnalysisCard analysis={stockAnalysis} />
+          </div>
+        )}
+
         {/* Content with truncation affordance */}
-        {displayed && (
+        {!stockAnalysis && displayed && (
           <div
             className={clsx(
               'mt-1.5 text-[13px] text-gray-300 leading-relaxed',

--- a/frontend/src/components/NewsAndEventsTimeline.jsx
+++ b/frontend/src/components/NewsAndEventsTimeline.jsx
@@ -1,0 +1,32 @@
+import clsx from 'clsx'
+import { newsEvents } from '../data/financeMockData'
+
+const typeClass = {
+  earnings: 'bg-purple-500/20 text-purple-300',
+  news: 'bg-blue-500/20 text-blue-300',
+  filing: 'bg-amber-500/20 text-amber-300',
+}
+
+export default function NewsAndEventsTimeline() {
+  return (
+    <section className="bg-surface-50 border border-surface-200 rounded-xl p-4">
+      <h3 className="text-sm font-semibold text-gray-200">News, Filings & Events</h3>
+      <p className="text-[10px] text-gray-600 mb-3">Timeline of catalysts and research inputs.</p>
+      <div className="space-y-3">
+        {newsEvents.map((event) => (
+          <div key={`${event.type}-${event.title}`} className="relative pl-5">
+            <div className="absolute left-1 top-1.5 w-2 h-2 rounded-full bg-accent" />
+            <div className="text-sm text-gray-300">{event.title}</div>
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-[10px] text-gray-500">
+              <span className={clsx('px-1.5 py-0.5 rounded', typeClass[event.type])}>{event.type}</span>
+              <span>{event.source}</span>
+              <span>{event.time}</span>
+              <span>{event.sentiment}</span>
+              <span>{event.impact} impact</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/PortfolioWorkspace.jsx
+++ b/frontend/src/components/PortfolioWorkspace.jsx
@@ -1,0 +1,61 @@
+import clsx from 'clsx'
+import { positions } from '../data/financeMockData'
+
+export default function PortfolioWorkspace() {
+  const totalWeight = positions.reduce((sum, p) => sum + p.weight, 0)
+  return (
+    <div className="flex-1 overflow-y-auto p-3 md:p-4 space-y-4">
+      <section className="grid md:grid-cols-4 gap-3">
+        <Metric label="Market value" value="$1,002,400" />
+        <Metric label="Daily P&L" value="+$8,420" positive />
+        <Metric label="Beta" value="1.14" />
+        <Metric label="Max drawdown" value="-11.8%" negative />
+      </section>
+      <section className="bg-surface-50 border border-surface-200 rounded-xl p-4">
+        <h3 className="text-sm font-semibold text-gray-200">Positions</h3>
+        <p className="text-[10px] text-gray-600 mb-3">Portfolio risk view establishes the UI contract for live positions and scenarios.</p>
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead className="text-gray-500"><tr><th className="text-left py-2">Symbol</th><th className="text-right">Weight</th><th className="text-right">Value</th><th className="text-right">P&L</th><th className="text-right">Risk</th></tr></thead>
+            <tbody>
+              {positions.map((position) => (
+                <tr key={position.symbol} className="border-t border-surface-200 text-gray-300">
+                  <td className="py-2 font-mono">{position.symbol}</td>
+                  <td className="text-right">{position.weight}%</td>
+                  <td className="text-right">{position.marketValue}</td>
+                  <td className={clsx('text-right', position.pnl >= 0 ? 'text-green-400' : 'text-red-400')}>{position.pnl >= 0 ? '+' : ''}{position.pnl}%</td>
+                  <td className="text-right">{position.risk}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+      <section className="grid md:grid-cols-2 gap-4">
+        <div className="bg-surface-50 border border-surface-200 rounded-xl p-4">
+          <h3 className="text-sm font-semibold text-gray-200 mb-3">Concentration</h3>
+          <div className="space-y-2">
+            {positions.map((p) => <div key={p.symbol}><div className="flex justify-between text-xs text-gray-400"><span>{p.symbol}</span><span>{p.weight}%</span></div><div className="h-2 bg-surface-100 rounded"><div className="h-2 bg-accent rounded" style={{ width: `${(p.weight / totalWeight) * 100}%` }} /></div></div>)}
+          </div>
+        </div>
+        <div className="bg-surface-50 border border-surface-200 rounded-xl p-4">
+          <h3 className="text-sm font-semibold text-gray-200 mb-3">Scenario Analysis</h3>
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            <Scenario name="Rates +50 bps" impact="-2.4%" />
+            <Scenario name="AI capex slowdown" impact="-6.8%" severe />
+            <Scenario name="USD -3%" impact="+1.1%" positive />
+            <Scenario name="Oil shock" impact="-0.9%" />
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function Metric({ label, value, positive, negative }) {
+  return <div className="bg-surface-50 border border-surface-200 rounded-xl p-4"><div className="text-xs text-gray-500">{label}</div><div className={clsx('mt-2 text-2xl font-mono', positive ? 'text-green-400' : negative ? 'text-red-400' : 'text-gray-100')}>{value}</div></div>
+}
+
+function Scenario({ name, impact, positive, severe }) {
+  return <div className={clsx('rounded-lg p-3 border', positive ? 'bg-green-500/10 border-green-500/20 text-green-300' : severe ? 'bg-red-500/10 border-red-500/20 text-red-300' : 'bg-surface-100 border-surface-200 text-gray-300')}><div>{name}</div><div className="mt-1 font-mono">{impact}</div></div>
+}

--- a/frontend/src/components/PriceChartPanel.jsx
+++ b/frontend/src/components/PriceChartPanel.jsx
@@ -1,0 +1,70 @@
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import clsx from 'clsx'
+import useAppStore from '../stores/appStore'
+import { mockCandles } from '../data/financeMockData'
+
+const RANGES = ['1M', '6M', 'YTD', '1Y', '5Y']
+
+export default function PriceChartPanel() {
+  const chartRange = useAppStore((s) => s.chartRange)
+  const setChartRange = useAppStore((s) => s.setChartRange)
+
+  return (
+    <section className="bg-surface-50 border border-surface-200 rounded-xl p-4 min-h-[360px]">
+      <div className="flex items-center justify-between gap-3 mb-3">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-200">Price Action</h3>
+          <p className="text-[10px] text-gray-600">Close price with 20/50-week moving averages and volume.</p>
+        </div>
+        <div className="flex items-center gap-1">
+          {RANGES.map((range) => (
+            <button
+              key={range}
+              onClick={() => setChartRange(range)}
+              className={clsx(
+                'px-2 py-1 rounded text-[10px] transition-colors',
+                chartRange === range ? 'bg-accent text-white' : 'bg-surface-100 text-gray-500 hover:text-gray-300'
+              )}
+            >
+              {range}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="h-56">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={mockCandles} margin={{ left: -12, right: 8, top: 10, bottom: 0 }}>
+            <defs>
+              <linearGradient id="priceFill" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#38bdf8" stopOpacity={0.35} />
+                <stop offset="100%" stopColor="#38bdf8" stopOpacity={0.02} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid stroke="#1f2937" strokeDasharray="3 3" />
+            <XAxis dataKey="date" tick={{ fill: '#6b7280', fontSize: 10 }} minTickGap={22} />
+            <YAxis tick={{ fill: '#6b7280', fontSize: 10 }} domain={['dataMin - 4', 'dataMax + 4']} />
+            <Tooltip contentStyle={{ background: '#111827', border: '1px solid #374151', color: '#e5e7eb' }} />
+            <Area type="monotone" dataKey="close" stroke="#38bdf8" strokeWidth={2} fill="url(#priceFill)" />
+            <Line type="monotone" dataKey="ma20" stroke="#f59e0b" strokeWidth={1.5} dot={false} />
+            <Line type="monotone" dataKey="ma50" stroke="#a78bfa" strokeWidth={1.5} dot={false} />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="h-20 mt-2">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={mockCandles} margin={{ left: -12, right: 8, top: 0, bottom: 0 }}>
+            <XAxis dataKey="date" hide />
+            <YAxis hide />
+            <Tooltip contentStyle={{ background: '#111827', border: '1px solid #374151', color: '#e5e7eb' }} />
+            <Bar dataKey="volume" fill="#4b5563" radius={[2, 2, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="flex items-center gap-4 mt-2 text-[10px] text-gray-500">
+        <span><span className="inline-block w-2 h-2 rounded-full bg-sky-400 mr-1" />Close</span>
+        <span><span className="inline-block w-2 h-2 rounded-full bg-amber-500 mr-1" />MA20</span>
+        <span><span className="inline-block w-2 h-2 rounded-full bg-violet-400 mr-1" />MA50</span>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/ResearchProvenancePanel.jsx
+++ b/frontend/src/components/ResearchProvenancePanel.jsx
@@ -1,0 +1,23 @@
+import { AlertTriangle, Database, Link as LinkIcon } from 'lucide-react'
+
+export default function ResearchProvenancePanel({ analysis }) {
+  const sources = analysis?.sources || []
+  return (
+    <section className="bg-surface-50 border border-surface-200 rounded-xl p-4">
+      <h3 className="text-sm font-semibold text-gray-200 flex items-center gap-2"><Database size={14} /> Provenance</h3>
+      <p className="text-[10px] text-gray-600 mt-1">Source and data-freshness trail for the latest research output.</p>
+      <div className="mt-3 space-y-2">
+        {sources.map((source) => (
+          <div key={`${source.title}-${source.type}`} className="bg-surface-100/60 rounded-lg p-2 text-xs">
+            <div className="flex items-center gap-2 text-gray-300"><LinkIcon size={12} /> {source.title}</div>
+            <div className="mt-1 text-gray-500">{source.publisher} · {source.type} · {source.published_at}</div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-3 rounded-lg border border-yellow-500/20 bg-yellow-500/10 p-2 text-xs text-yellow-200 flex gap-2">
+        <AlertTriangle size={13} className="shrink-0 mt-0.5" />
+        Live provider integration is pending; values in this PR are demo fixtures that establish the UI contract.
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/StockAnalysisCard.jsx
+++ b/frontend/src/components/StockAnalysisCard.jsx
@@ -1,0 +1,46 @@
+import clsx from 'clsx'
+
+function ratingClass(rating) {
+  if (/buy/i.test(rating)) return 'bg-green-500/20 text-green-300'
+  if (/sell|under/i.test(rating)) return 'bg-red-500/20 text-red-300'
+  if (/hold|neutral/i.test(rating)) return 'bg-yellow-500/20 text-yellow-300'
+  return 'bg-blue-500/20 text-blue-300'
+}
+
+export default function StockAnalysisCard({ analysis }) {
+  if (!analysis) return null
+  return (
+    <section className="bg-surface-50 border border-surface-200 rounded-xl p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-200">Agent Investment View</h3>
+          <p className="text-[10px] text-gray-600">Structured thesis card generated from the stock-analysis schema.</p>
+        </div>
+        <span className={clsx('px-2 py-1 rounded text-xs font-semibold', ratingClass(analysis.rating))}>{analysis.rating}</span>
+      </div>
+      <div className="grid grid-cols-3 gap-3 mt-4">
+        <Kpi label="Target" value={`$${analysis.target_price}`} />
+        <Kpi label="Upside" value={`${analysis.upside_percent}%`} positive />
+        <Kpi label="Confidence" value={`${analysis.confidence}%`} />
+      </div>
+      <p className="mt-4 text-sm text-gray-300 leading-relaxed">{analysis.summary}</p>
+      <div className="mt-4 bg-surface-100/60 rounded-lg p-3">
+        <div className="text-xs text-gray-500 mb-1">Base thesis</div>
+        <div className="text-sm text-gray-300">{analysis.thesis}</div>
+      </div>
+      <div className="grid md:grid-cols-3 gap-3 mt-4 text-xs">
+        <List title="Key drivers" items={analysis.key_drivers} color="text-green-300" />
+        <List title="Risks" items={analysis.risks} color="text-red-300" />
+        <List title="Catalysts" items={analysis.catalysts} color="text-sky-300" />
+      </div>
+    </section>
+  )
+}
+
+function Kpi({ label, value, positive }) {
+  return <div className="bg-surface-100 rounded-lg p-3"><div className="text-[10px] text-gray-500 uppercase tracking-wide">{label}</div><div className={clsx('mt-1 text-lg font-mono', positive ? 'text-green-300' : 'text-gray-100')}>{value}</div></div>
+}
+
+function List({ title, items = [], color }) {
+  return <div><div className={clsx('font-medium mb-1', color)}>{title}</div><ul className="space-y-1 text-gray-400 list-disc list-inside">{items.map((item) => <li key={item}>{item}</li>)}</ul></div>
+}

--- a/frontend/src/components/StockHeader.jsx
+++ b/frontend/src/components/StockHeader.jsx
@@ -1,0 +1,50 @@
+import { Clock, Database } from 'lucide-react'
+import clsx from 'clsx'
+import useAppStore from '../stores/appStore'
+import { mockQuotes } from '../data/financeMockData'
+
+export default function StockHeader() {
+  const selectedSymbol = useAppStore((s) => s.selectedSymbol)
+  const quote = mockQuotes[selectedSymbol]
+
+  if (!quote) {
+    return <div className="bg-surface-50 border border-surface-200 rounded-xl p-4 text-sm text-gray-500">Select a ticker to begin research.</div>
+  }
+
+  const up = quote.change >= 0
+  return (
+    <section className="bg-surface-50 border border-surface-200 rounded-xl p-4">
+      <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h2 className="text-2xl font-semibold text-gray-100">{quote.symbol}</h2>
+            <span className="text-sm text-gray-400">{quote.name}</span>
+            <span className="text-[10px] uppercase tracking-[0.14em] bg-accent/15 text-accent-light rounded px-2 py-0.5">{quote.rating}</span>
+          </div>
+          <div className="mt-2 flex items-end gap-3">
+            <span className="text-3xl font-mono text-gray-100">${quote.price.toFixed(2)}</span>
+            <span className={clsx('text-sm font-medium pb-1', up ? 'text-green-400' : 'text-red-400')}>
+              {up ? '+' : ''}{quote.change.toFixed(2)} ({up ? '+' : ''}{quote.changePercent.toFixed(2)}%)
+            </span>
+          </div>
+        </div>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-xs">
+          <Metric label="Market cap" value={quote.marketCap} />
+          <Metric label="Volume" value={quote.volume} />
+          <Metric label="Avg volume" value={quote.averageVolume} />
+          <Metric label="52W range" value={`$${quote.week52Low}-$${quote.week52High}`} />
+        </div>
+      </div>
+      <div className="mt-3 flex flex-wrap items-center gap-3 text-[10px] text-gray-500">
+        <span>Pre-market ${quote.preMarket}</span>
+        <span>After-hours ${quote.afterHours}</span>
+        <span className="flex items-center gap-1"><Clock size={11} /> {quote.updatedAt}</span>
+        <span className="flex items-center gap-1"><Database size={11} /> {quote.source}</span>
+      </div>
+    </section>
+  )
+}
+
+function Metric({ label, value }) {
+  return <div><div className="text-gray-500">{label}</div><div className="mt-0.5 text-gray-200 font-mono">{value}</div></div>
+}

--- a/frontend/src/components/StockWorkspace.jsx
+++ b/frontend/src/components/StockWorkspace.jsx
@@ -1,0 +1,32 @@
+import TickerSearch from './TickerSearch'
+import WatchlistPanel from './WatchlistPanel'
+import StockHeader from './StockHeader'
+import PriceChartPanel from './PriceChartPanel'
+import StockAnalysisCard from './StockAnalysisCard'
+import ResearchProvenancePanel from './ResearchProvenancePanel'
+import FundamentalsPanel from './FundamentalsPanel'
+import NewsAndEventsTimeline from './NewsAndEventsTimeline'
+import { stockAnalysis } from '../data/financeMockData'
+
+export default function StockWorkspace() {
+  return (
+    <div className="flex-1 overflow-y-auto p-3 md:p-4">
+      <div className="grid xl:grid-cols-[260px_minmax(0,1fr)] gap-4">
+        <div className="space-y-4">
+          <TickerSearch />
+          <WatchlistPanel />
+          <ResearchProvenancePanel analysis={stockAnalysis} />
+        </div>
+        <main className="space-y-4 min-w-0">
+          <StockHeader />
+          <div className="grid 2xl:grid-cols-[minmax(0,1.4fr)_minmax(360px,0.8fr)] gap-4">
+            <PriceChartPanel />
+            <StockAnalysisCard analysis={stockAnalysis} />
+          </div>
+          <FundamentalsPanel />
+          <NewsAndEventsTimeline />
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/TickerSearch.jsx
+++ b/frontend/src/components/TickerSearch.jsx
@@ -1,0 +1,26 @@
+import { Search } from 'lucide-react'
+import useAppStore from '../stores/appStore'
+import { mockQuotes } from '../data/financeMockData'
+
+export default function TickerSearch() {
+  const selectedSymbol = useAppStore((s) => s.selectedSymbol)
+  const setSelectedSymbol = useAppStore((s) => s.setSelectedSymbol)
+  const watchlist = useAppStore((s) => s.watchlist)
+
+  const symbols = Array.from(new Set([...watchlist, ...Object.keys(mockQuotes)]))
+
+  return (
+    <div className="relative">
+      <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" />
+      <select
+        value={selectedSymbol || ''}
+        onChange={(e) => setSelectedSymbol(e.target.value)}
+        className="w-full bg-surface-100 border border-surface-200 rounded-lg pl-9 pr-3 py-2 text-sm text-gray-200 focus:outline-none focus:ring-1 focus:ring-accent/60"
+      >
+        {symbols.map((symbol) => (
+          <option key={symbol} value={symbol}>{symbol} · {mockQuotes[symbol]?.name || 'Tracked equity'}</option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/frontend/src/components/WatchlistPanel.jsx
+++ b/frontend/src/components/WatchlistPanel.jsx
@@ -1,0 +1,52 @@
+import clsx from 'clsx'
+import useAppStore from '../stores/appStore'
+import { mockQuotes } from '../data/financeMockData'
+
+function Change({ value }) {
+  return <span className={clsx(value >= 0 ? 'text-green-400' : 'text-red-400')}>{value >= 0 ? '+' : ''}{value.toFixed(2)}%</span>
+}
+
+export default function WatchlistPanel() {
+  const watchlist = useAppStore((s) => s.watchlist)
+  const selectedSymbol = useAppStore((s) => s.selectedSymbol)
+  const setSelectedSymbol = useAppStore((s) => s.setSelectedSymbol)
+
+  return (
+    <aside className="bg-surface-50 border border-surface-200 rounded-xl overflow-hidden">
+      <div className="px-3 py-2 border-b border-surface-200">
+        <h3 className="text-xs font-semibold text-gray-300">Watchlist</h3>
+        <p className="text-[10px] text-gray-600">Demo quotes until live data endpoints are connected.</p>
+      </div>
+      <div className="divide-y divide-surface-200">
+        {watchlist.map((symbol) => {
+          const quote = mockQuotes[symbol]
+          return (
+            <button
+              key={symbol}
+              onClick={() => setSelectedSymbol(symbol)}
+              className={clsx(
+                'w-full text-left px-3 py-2.5 hover:bg-surface-100 transition-colors',
+                selectedSymbol === symbol && 'bg-accent/10'
+              )}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div>
+                  <div className="text-sm font-semibold text-gray-100">{symbol}</div>
+                  <div className="text-[10px] text-gray-500 truncate max-w-32">{quote?.name}</div>
+                </div>
+                <div className="text-right">
+                  <div className="text-sm text-gray-200 font-mono">${quote?.price.toFixed(2)}</div>
+                  <div className="text-[11px]"><Change value={quote?.changePercent || 0} /></div>
+                </div>
+              </div>
+              <div className="mt-1 flex items-center justify-between text-[10px] text-gray-500">
+                <span>{quote?.rating || '—'}</span>
+                <span>{quote?.alertCount || 0} alerts</span>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+    </aside>
+  )
+}

--- a/frontend/src/data/financeMockData.js
+++ b/frontend/src/data/financeMockData.js
@@ -1,0 +1,102 @@
+export const mockQuotes = {
+  NVDA: {
+    symbol: 'NVDA', name: 'NVIDIA Corp.', price: 142.63, change: 3.18, changePercent: 2.28,
+    marketCap: '3.51T', volume: '176.2M', averageVolume: '214.7M', week52Low: 82.33, week52High: 153.13,
+    preMarket: 143.21, afterHours: 142.91, updatedAt: '2026-06-07T20:00:00Z', source: 'Demo market feed',
+    rating: 'Buy', alertCount: 2,
+  },
+  AAPL: {
+    symbol: 'AAPL', name: 'Apple Inc.', price: 203.92, change: -1.34, changePercent: -0.65,
+    marketCap: '3.06T', volume: '58.4M', averageVolume: '61.1M', week52Low: 169.21, week52High: 237.49,
+    preMarket: 204.10, afterHours: 203.77, updatedAt: '2026-06-07T20:00:00Z', source: 'Demo market feed',
+    rating: 'Hold', alertCount: 1,
+  },
+  MSFT: {
+    symbol: 'MSFT', name: 'Microsoft Corp.', price: 474.18, change: 4.72, changePercent: 1.01,
+    marketCap: '3.52T', volume: '27.5M', averageVolume: '29.2M', week52Low: 359.11, week52High: 481.00,
+    preMarket: 475.20, afterHours: 474.88, updatedAt: '2026-06-07T20:00:00Z', source: 'Demo market feed',
+    rating: 'Buy', alertCount: 0,
+  },
+  TSLA: {
+    symbol: 'TSLA', name: 'Tesla Inc.', price: 178.44, change: -5.82, changePercent: -3.16,
+    marketCap: '568.7B', volume: '121.6M', averageVolume: '104.9M', week52Low: 138.80, week52High: 299.29,
+    preMarket: 176.80, afterHours: 177.12, updatedAt: '2026-06-07T20:00:00Z', source: 'Demo market feed',
+    rating: 'Watch', alertCount: 3,
+  },
+}
+
+export const mockCandles = Array.from({ length: 48 }, (_, idx) => {
+  const base = 118 + idx * 0.48 + Math.sin(idx / 4) * 4
+  return {
+    date: `W${idx + 1}`,
+    close: Number(base.toFixed(2)),
+    ma20: Number((base - 1.8 + Math.sin(idx / 6)).toFixed(2)),
+    ma50: Number((base - 4.1 + Math.cos(idx / 8)).toFixed(2)),
+    volume: Math.round(110 + Math.sin(idx / 3) * 38 + idx * 1.3),
+  }
+})
+
+export const marketIndexes = [
+  { symbol: 'SPY', label: 'S&P 500 ETF', price: 612.42, changePercent: 0.84 },
+  { symbol: 'QQQ', label: 'Nasdaq 100 ETF', price: 542.18, changePercent: 1.26 },
+  { symbol: 'DIA', label: 'Dow ETF', price: 427.05, changePercent: 0.31 },
+  { symbol: 'IWM', label: 'Russell 2000 ETF', price: 221.73, changePercent: -0.18 },
+]
+
+export const sectorPerformance = [
+  { name: 'Technology', changePercent: 1.72 },
+  { name: 'Communication', changePercent: 0.96 },
+  { name: 'Financials', changePercent: 0.42 },
+  { name: 'Industrials', changePercent: 0.28 },
+  { name: 'Healthcare', changePercent: -0.21 },
+  { name: 'Energy', changePercent: -0.63 },
+  { name: 'Utilities', changePercent: -0.77 },
+  { name: 'Consumer Disc.', changePercent: 0.13 },
+]
+
+export const stockAnalysis = {
+  type: 'stock_analysis', symbol: 'NVDA', company_name: 'NVIDIA Corp.', rating: 'Buy', target_price: 168,
+  current_price: 142.63, upside_percent: 17.8, confidence: 74, horizon: '6-12 months',
+  summary: 'AI accelerator demand remains the dominant driver, but the setup requires monitoring hyperscaler capex concentration and gross-margin normalization.',
+  thesis: 'Base case assumes continued data-center growth, networking attach-rate expansion, and software monetization offsetting slower gaming recovery.',
+  key_drivers: ['Data-center revenue growth', 'Blackwell supply ramp', 'Networking attach rates', 'Enterprise inference adoption'],
+  risks: ['Hyperscaler capex pause', 'Export restrictions', 'ASIC substitution', 'Gross-margin compression'],
+  catalysts: ['Next earnings call', 'Blackwell availability update', 'Large enterprise AI deployments'],
+  sources: [
+    { title: 'Latest company filings', publisher: 'SEC', type: 'filing', published_at: '2026-05-29' },
+    { title: 'Demo quote snapshot', publisher: 'EdgeCitadel demo feed', type: 'quote', published_at: '2026-06-07' },
+  ],
+}
+
+export const fundamentals = [
+  { period: 'FY22', revenue: 27, eps: 3.85, margin: 25, fcf: 8.1 },
+  { period: 'FY23', revenue: 27, eps: 3.34, margin: 16, fcf: 3.8 },
+  { period: 'FY24', revenue: 61, eps: 12.96, margin: 49, fcf: 27.0 },
+  { period: 'FY25', revenue: 130, eps: 29.75, margin: 56, fcf: 60.8 },
+]
+
+export const peers = [
+  { symbol: 'NVDA', growth: 88, grossMargin: 75, forwardPE: 32, evSales: 18.4, rating: 'Buy' },
+  { symbol: 'AMD', growth: 28, grossMargin: 52, forwardPE: 29, evSales: 7.8, rating: 'Hold' },
+  { symbol: 'AVGO', growth: 22, grossMargin: 69, forwardPE: 27, evSales: 12.3, rating: 'Buy' },
+  { symbol: 'INTC', growth: 5, grossMargin: 41, forwardPE: 21, evSales: 2.1, rating: 'Watch' },
+]
+
+export const newsEvents = [
+  { type: 'earnings', title: 'Next earnings window expected in late August', source: 'Calendar', sentiment: 'neutral', impact: 'high', time: '2026-08-27' },
+  { type: 'news', title: 'Cloud AI infrastructure demand remains elevated', source: 'Demo News', sentiment: 'positive', impact: 'medium', time: '2026-06-06' },
+  { type: 'filing', title: 'Quarterly filing reviewed by research agent', source: 'SEC', sentiment: 'neutral', impact: 'medium', time: '2026-05-29' },
+]
+
+export const positions = [
+  { symbol: 'NVDA', weight: 12.5, marketValue: '$125,400', pnl: 18.2, risk: 'High' },
+  { symbol: 'MSFT', weight: 9.8, marketValue: '$98,100', pnl: 7.4, risk: 'Medium' },
+  { symbol: 'AAPL', weight: 7.6, marketValue: '$76,200', pnl: -1.3, risk: 'Medium' },
+  { symbol: 'SPY', weight: 22.0, marketValue: '$220,000', pnl: 5.1, risk: 'Low' },
+]
+
+export const alerts = [
+  { id: 'a1', symbol: 'NVDA', severity: 'high', rule: 'Price above target watch band', trigger: 'Crossed $142 with volume above average', status: 'open', time: '2026-06-07T19:42:00Z' },
+  { id: 'a2', symbol: 'TSLA', severity: 'medium', rule: 'Volume spike', trigger: 'Volume 1.4x 30-day average', status: 'open', time: '2026-06-07T18:10:00Z' },
+  { id: 'a3', symbol: 'AAPL', severity: 'low', rule: 'News sentiment drift', trigger: 'Negative product-cycle headlines increased', status: 'acknowledged', time: '2026-06-06T21:15:00Z' },
+]

--- a/frontend/src/stores/appStore.js
+++ b/frontend/src/stores/appStore.js
@@ -10,7 +10,7 @@ const useAppStore = create((set, get) => ({
   selectedAgent: null,
 
   // Navigation
-  activeTab: 'chat',
+  activeTab: 'market',
 
   // Real-time messages — canonical envelopes
   realtimeMessages: [],
@@ -37,6 +37,22 @@ const useAppStore = create((set, get) => ({
   // Mobile sidebar
   sidebarOpen: false,
 
+  // Finance workspace state — demo-first surfaces that can be backed by
+  // live market-data endpoints as they become available.
+  selectedSymbol: 'NVDA',
+  watchlist: ['NVDA', 'AAPL', 'MSFT', 'TSLA'],
+  quotes: {},
+  candles: {},
+  chartRange: '1Y',
+  chartInterval: '1w',
+  latestAnalysis: null,
+  fundamentals: {},
+  valuations: {},
+  newsEvents: {},
+  portfolio: null,
+  positions: [],
+  alerts: [],
+
   // v0.1 messaging surfaces
   agentQueue: {}, // agentQueue[agentId] = {pending, ack_pending, num_waiting}
   poisonEvents: {}, // poisonEvents[agentId] = [advisories]
@@ -57,6 +73,29 @@ const useAppStore = create((set, get) => ({
   setAgents: (agents) => set({ agents }),
 
   setSelectedAgent: (agent) => set({ selectedAgent: agent }),
+  setSelectedSymbol: (symbol) => set({ selectedSymbol: symbol }),
+  setWatchlist: (watchlist) => set({ watchlist: watchlist || [] }),
+  setQuote: (symbol, quote) => set((state) => ({
+    quotes: { ...state.quotes, [symbol]: quote },
+  })),
+  setCandles: (symbol, candles) => set((state) => ({
+    candles: { ...state.candles, [symbol]: candles || [] },
+  })),
+  setChartRange: (range) => set({ chartRange: range }),
+  setChartInterval: (interval) => set({ chartInterval: interval }),
+  setLatestAnalysis: (analysis) => set({ latestAnalysis: analysis }),
+  setFundamentals: (symbol, rows) => set((state) => ({
+    fundamentals: { ...state.fundamentals, [symbol]: rows || [] },
+  })),
+  setValuation: (symbol, value) => set((state) => ({
+    valuations: { ...state.valuations, [symbol]: value },
+  })),
+  setNewsEvents: (symbol, events) => set((state) => ({
+    newsEvents: { ...state.newsEvents, [symbol]: events || [] },
+  })),
+  setPortfolio: (portfolio) => set({ portfolio }),
+  setPositions: (positions) => set({ positions: positions || [] }),
+  setAlerts: (alerts) => set({ alerts: alerts || [] }),
 
   updateAgentStatus: (agentId, agentState) =>
     set((state) => ({


### PR DESCRIPTION
### Motivation
- Introduce a demo-first finance research workspace and UI surfaces for market, research, portfolio, and alerts while preserving existing agent console flows and legacy deep-links. 
- Provide thin API client wrappers to enable future switch from demo fixtures to live market providers without component changes.

### Description
- Replaces the previous 1-5 tab set with product tabs: `market`, `research`, `portfolio`, `alerts`, and `agents`, and remaps keyboard shortcuts accordingly in `App.jsx` and `Layout.jsx`.
- Adds a finance research feature set including many new components: `StockWorkspace`, `MarketOverview`, `PortfolioWorkspace`, `AlertCenter`, `StockHeader`, `PriceChartPanel`, `FundamentalsPanel`, `StockAnalysisCard`, `NewsAndEventsTimeline`, `WatchlistPanel`, `TickerSearch`, and `ResearchProvenancePanel` under `frontend/src/components` and demo data in `frontend/src/data/financeMockData.js`.
- Introduces `AgentsConsole.jsx` that consolidates legacy agent-related sub-tabs (`chat`, `flow`, `logs`, `tasks`, `registry`, `detail`) and preserves deep-link compatibility by normalizing old activeTab values to the new `agents` top-level tab in `Layout.jsx`.
- Extends `frontend/src/api/client.js` with thin market/research/portfolio/alerts endpoints (`getQuote`, `getBatchQuotes`, `getCandles`, `getFundamentals`, `getValuation`, `getNewsEvents`, `getPortfolio`, `getPositions`, `getAlerts`).
- Extends `frontend/src/stores/appStore.js` with finance workspace state (selected symbol, watchlist, quotes, candles, chart settings, latest analysis, fundamentals, valuations, newsEvents, portfolio, positions, alerts) and corresponding setters; changes default `activeTab` to `market`.
- Updates `MessageBubble.jsx` to detect `stock_analysis` payloads and render structured `StockAnalysisCard` summaries inline.
- Small UX/branding changes in `HeaderBar.jsx` and layout/tab bar styling and a note preserving a legacy overlay sidebar behavior for mobile.

### Testing
- Built the frontend and ran unit/smoke tests with `npm run build` and `npm test`; both completed successfully.
- Performed a local dev smoke test to verify navigation between new tabs, agent console sub-tabs, and rendering of demo finance fixtures; no runtime errors observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2096e8f814832c972ee7702f9f1fe5)